### PR TITLE
Add predictors layout toggles and new a1b/a2b prototype screens

### DIFF
--- a/app/assets/javascripts/02/predictors-a1-layout-toggle.js
+++ b/app/assets/javascripts/02/predictors-a1-layout-toggle.js
@@ -1,0 +1,29 @@
+//
+// a1 / a1b – activate Return to OASys as a layout toggle
+//
+
+const activateLayoutToggleButton = (href) => {
+  const button = document.querySelector('.assessment-service-header .assessment-layout__return-to-oasys')
+  if (!button) return
+
+  button.setAttribute('href', href)
+  button.removeAttribute('aria-disabled')
+  button.removeAttribute('tabindex')
+  button.removeAttribute('data-predictors-inactive-link')
+  button.querySelector('[data-predictors-prototype-only-hint]')?.remove()
+}
+
+export const initA1LayoutToggleButtons = () => {
+  const path = window.location.pathname
+
+  if (!(path.includes('/02/') || path.includes('/dev/'))) return
+
+  if (path.includes('/a1b')) {
+    activateLayoutToggleButton('a1.html')
+    return
+  }
+
+  if (path.endsWith('/a1') || path.includes('/a1.html')) {
+    activateLayoutToggleButton('a1b.html')
+  }
+}

--- a/app/assets/javascripts/02/predictors-a2-layout-toggle.js
+++ b/app/assets/javascripts/02/predictors-a2-layout-toggle.js
@@ -1,0 +1,27 @@
+//
+// a2 / a2b – activate Return to OASys as a layout toggle
+//
+
+const activateLayoutToggleButton = (href) => {
+  const button = document.querySelector('.assessment-service-header .assessment-layout__return-to-oasys')
+  if (!button) return
+
+  button.setAttribute('href', href)
+  button.removeAttribute('aria-disabled')
+  button.removeAttribute('tabindex')
+  button.removeAttribute('data-predictors-inactive-link')
+  button.querySelector('[data-predictors-prototype-only-hint]')?.remove()
+}
+
+export const initA2LayoutToggleButtons = () => {
+  const path = window.location.pathname
+
+  if (path.includes('/a2b')) {
+    activateLayoutToggleButton('a2.html')
+    return
+  }
+
+  if (path.endsWith('/a2') || path.includes('/a2.html')) {
+    activateLayoutToggleButton('a2b.html')
+  }
+}

--- a/app/assets/javascripts/02/predictors-a2b-page.js
+++ b/app/assets/javascripts/02/predictors-a2b-page.js
@@ -1,0 +1,207 @@
+//
+// a2b – current offence + offending history (merged a1 + a2)
+//
+
+import {
+  initConvictionDate,
+  isConvictionDateEditPanelOpen,
+  persistConvictionDateState
+} from '../conviction-date.js'
+import {
+  getDefaultFirstSanctionDateParts,
+  getOffenderDateOfBirthParts,
+  getPredictorsAssessmentSession
+} from './predictors-assessment-session.js'
+import {
+  captureCheckAnswersEditSnapshot,
+  completePredictorsPageAndContinue,
+  isPredictorsCheckAnswersEdit
+} from './predictors-change-scroll.js'
+import { initA1OffenceDisplayToggle } from '../tiering-a1-display-toggle.js'
+import { initA2bCurrentOffenceToggle } from '../a2b-current-offence-toggle.js'
+import {
+  calculateAgeOnDate,
+  getA1FieldsFromForm,
+  getA2FieldsFromForm,
+  isValidDateParts,
+  normaliseDateParts
+} from './predictors-journey.js'
+
+const A1_PNC_VIEWER_URL = '/02/pnc'
+
+const FIRST_SANCTION_DATE_INPUT_IDS = [
+  'first-sanction-date-day',
+  'first-sanction-date-month',
+  'first-sanction-date-year'
+]
+
+const setFirstSanctionDateValues = (parts) => {
+  const dayInput = document.getElementById('first-sanction-date-day')
+  const monthInput = document.getElementById('first-sanction-date-month')
+  const yearInput = document.getElementById('first-sanction-date-year')
+
+  if (dayInput) dayInput.value = parts.day || ''
+  if (monthInput) monthInput.value = parts.month || ''
+  if (yearInput) yearInput.value = parts.year || ''
+}
+
+const getFirstSanctionDatePartsFromDom = () =>
+  normaliseDateParts({
+    day: document.getElementById('first-sanction-date-day')?.value,
+    month: document.getElementById('first-sanction-date-month')?.value,
+    year: document.getElementById('first-sanction-date-year')?.value
+  })
+
+const initA1FooterCrownLink = () => {
+  const crown = document.querySelector('.govuk-footer__crown')
+  if (!crown || crown.closest('[data-a1-footer-crown-link]')) return
+
+  const link = document.createElement('a')
+  link.href = A1_PNC_VIEWER_URL
+  link.target = '_blank'
+  link.rel = 'noopener noreferrer'
+  link.className = 'govuk-footer__crown-link'
+  link.dataset.a1FooterCrownLink = 'true'
+  link.setAttribute('aria-label', 'Open PNC record (opens in new tab)')
+
+  crown.setAttribute('aria-hidden', 'true')
+  crown.parentNode?.replaceChild(link, crown)
+  link.appendChild(crown)
+}
+
+window.GOVUKPrototypeKit.documentReady(() => {
+  if (!window.location.pathname.includes('/02/')) return
+
+  const form = document.getElementById('predictors-a2b-form')
+  if (!form) return
+
+  initConvictionDate()
+  initA1OffenceDisplayToggle()
+  initA2bCurrentOffenceToggle()
+  initA1FooterCrownLink()
+
+  document.querySelector('[data-predictors-offence-browse-link]')?.addEventListener('click', () => {
+    persistConvictionDateState({ editing: isConvictionDateEditPanelOpen() })
+  })
+
+  const session = getPredictorsAssessmentSession()
+  const offenderFirstName = form.dataset.offenderFirstName || 'Alex'
+  const ageResult = document.getElementById('first-sanction-age-result')
+  let ageResultAnnounceTimeoutId = null
+
+  if (session.firstSanctionDate) {
+    setFirstSanctionDateValues(session.firstSanctionDate)
+  } else {
+    setFirstSanctionDateValues(getDefaultFirstSanctionDateParts())
+  }
+
+  const hideAgeResult = () => {
+    if (!ageResult) return
+    if (ageResultAnnounceTimeoutId) {
+      window.clearTimeout(ageResultAnnounceTimeoutId)
+      ageResultAnnounceTimeoutId = null
+    }
+    ageResult.textContent = ''
+    ageResult.removeAttribute('data-age-message')
+    ageResult.classList.add('first-sanction-age-result--hidden')
+  }
+
+  const showAgeResult = (age) => {
+    if (!ageResult) return
+    const message = `Age: ${offenderFirstName} was ${age} on this date`
+    if (ageResult.getAttribute('data-age-message') === message) return
+
+    const previousMessage = ageResult.getAttribute('data-age-message')
+    ageResult.setAttribute('data-age-message', message)
+    ageResult.classList.remove('first-sanction-age-result--hidden')
+
+    const render = () => {
+      ageResult.innerHTML = `<strong>Age:</strong> ${offenderFirstName} was ${age} on this date`
+    }
+
+    if (!previousMessage) {
+      render()
+      return
+    }
+
+    if (ageResultAnnounceTimeoutId) window.clearTimeout(ageResultAnnounceTimeoutId)
+    ageResult.textContent = ''
+    ageResultAnnounceTimeoutId = window.setTimeout(() => {
+      ageResultAnnounceTimeoutId = null
+      if (ageResult.getAttribute('data-age-message') !== message) return
+      render()
+    }, 0)
+  }
+
+  const updateFirstSanctionAgeResult = ({ hideWhenInvalid = true } = {}) => {
+    const dateParts = getFirstSanctionDatePartsFromDom()
+
+    if (!isValidDateParts(dateParts)) {
+      if (hideWhenInvalid) hideAgeResult()
+      return
+    }
+
+    const age = calculateAgeOnDate(getOffenderDateOfBirthParts(), dateParts)
+    if (age == null) {
+      if (hideWhenInvalid) hideAgeResult()
+      return
+    }
+
+    showAgeResult(age)
+  }
+
+  FIRST_SANCTION_DATE_INPUT_IDS.forEach((id) => {
+    const input = document.getElementById(id)
+    if (!input) return
+    input.addEventListener('input', () => updateFirstSanctionAgeResult({ hideWhenInvalid: false }))
+    input.addEventListener('blur', () => updateFirstSanctionAgeResult())
+  })
+
+  form.querySelector('[data-first-sanction-date-field]')?.addEventListener('focusout', (event) => {
+    const dateField = event.currentTarget
+    if (dateField.contains(event.relatedTarget)) return
+    updateFirstSanctionAgeResult()
+  })
+
+  updateFirstSanctionAgeResult()
+
+  if (session.totalSanctions) {
+    const totalSanctions = form.querySelector('#total-sanctions')
+    if (totalSanctions) totalSanctions.value = session.totalSanctions
+  }
+  if (session.violentSanctions) {
+    const violentSanctions = form.querySelector('#violent-sanctions-other')
+    if (violentSanctions) violentSanctions.value = session.violentSanctions
+  }
+  if (session.sexualOffence) {
+    const sexualOffenceInput = form.querySelector(
+      `input[name="sexual_offence"][value="${session.sexualOffence}"]`
+    )
+    if (sexualOffenceInput) sexualOffenceInput.checked = true
+  }
+
+  if (isPredictorsCheckAnswersEdit()) {
+    captureCheckAnswersEditSnapshot({
+      ...getA1FieldsFromForm(form),
+      ...getA2FieldsFromForm(form)
+    })
+  }
+
+  form.addEventListener('submit', (event) => {
+    event.preventDefault()
+
+    const newFields = {
+      ...getA1FieldsFromForm(form),
+      ...getA2FieldsFromForm(form),
+      convictionDateEditMode: false
+    }
+
+    const sexualOffence = newFields.sexualOffence
+
+    window.location.href = completePredictorsPageAndContinue(
+      'a2',
+      sexualOffence === 'yes' ? 'a3.html' : 'a4.html',
+      newFields
+    )
+  })
+})

--- a/app/assets/javascripts/02/predictors-a3-page.js
+++ b/app/assets/javascripts/02/predictors-a3-page.js
@@ -11,7 +11,7 @@ import {
 } from './predictors-change-scroll.js'
 import { getA3FieldsFromForm, isA3Complete } from './predictors-journey.js'
 import { getPredictorsAssessmentSession } from './predictors-assessment-session.js'
-import { initTieringInactiveLinks } from '../tiering-inactive-links.js'
+import { initPredictorsInactiveLinks } from './predictors-inactive-links.js'
 
 const restoreRadio = (form, name, value) => {
   if (!value) return
@@ -88,7 +88,7 @@ window.GOVUKPrototypeKit.documentReady(() => {
     return
   }
 
-  initTieringInactiveLinks(form)
+  initPredictorsInactiveLinks(form)
 
   const shouldRestoreSavedAnswers =
     isPredictorsCheckAnswersEdit() || isPredictorsBackNavigation() || isA3Complete(session)

--- a/app/assets/javascripts/02/predictors-a4-page.js
+++ b/app/assets/javascripts/02/predictors-a4-page.js
@@ -1,5 +1,5 @@
 //
-// a4 – community supervision and date
+// a4 – community supervision start date
 //
 
 import {
@@ -10,11 +10,15 @@ import {
   scrollToPredictorsChangeTarget,
   PREDICTORS_CHANGE_ANCHORS
 } from './predictors-change-scroll.js'
-import { restoreDateInputs, setConditionalVisible } from '../tiering-conditional-fields.js'
-import { getA4FieldsFromForm, getFirstIncompleteA3Page, getPostA4ContinueHref, isDateComplete } from './predictors-journey.js'
-import { getPredictorsAssessmentSession, setPredictorsAssessmentSession } from './predictors-assessment-session.js'
-
-const SUPERVISED_CONDITIONAL_ID = 'conditional-supervised-in-community-yes'
+import { restoreDateInputs } from './predictors-conditional-fields.js'
+import {
+  getA4FieldsFromForm,
+  getDefaultCommunityDateParts,
+  getFirstIncompleteA3Page,
+  getPostA4ContinueHref,
+  isDateComplete
+} from './predictors-journey.js'
+import { getPredictorsAssessmentSession } from './predictors-assessment-session.js'
 
 const getA4BackHref = (session) => {
   if (session.sexualOffence !== 'yes') return 'a2.html'
@@ -34,29 +38,22 @@ window.GOVUKPrototypeKit.documentReady(() => {
     backLink.href = getPredictorsBackLinkHref(getA4BackHref(session))
   }
 
-  if (session.supervisedInCommunity) {
-    const input = form.querySelector(
-      `input[name="supervised_in_community"][value="${session.supervisedInCommunity}"]`
-    )
-    if (input) input.checked = true
-  }
+  const communityDate = isDateComplete(session.communityDate)
+    ? session.communityDate
+    : getDefaultCommunityDateParts()
 
-  const hashTarget = window.location.hash.slice(1)
-  const supervisedInCommunity = session.supervisedInCommunity
-  const showSupervisedDate =
-    supervisedInCommunity === 'yes' || hashTarget === PREDICTORS_CHANGE_ANCHORS.supervisedCommunityDate
-
-  if (showSupervisedDate) {
-    setConditionalVisible(SUPERVISED_CONDITIONAL_ID, true)
-    restoreDateInputs(form, 'supervised-community-date', session.communityDate)
-  }
+  restoreDateInputs(form, 'supervised-community-date', communityDate)
 
   if (isPredictorsCheckAnswersEdit()) {
     captureCheckAnswersEditSnapshot(getA4FieldsFromForm(form))
   }
 
-  if (hashTarget === PREDICTORS_CHANGE_ANCHORS.supervisedInCommunity || hashTarget === PREDICTORS_CHANGE_ANCHORS.supervisedCommunityDate) {
-    scrollToPredictorsChangeTarget(hashTarget)
+  const hashTarget = window.location.hash.slice(1)
+  if (
+    hashTarget === PREDICTORS_CHANGE_ANCHORS.supervisedCommunityDate ||
+    hashTarget === PREDICTORS_CHANGE_ANCHORS.supervisedInCommunity
+  ) {
+    scrollToPredictorsChangeTarget(PREDICTORS_CHANGE_ANCHORS.supervisedCommunityDate)
   }
 
   form.addEventListener('submit', (event) => {
@@ -64,14 +61,7 @@ window.GOVUKPrototypeKit.documentReady(() => {
 
     const newFields = getA4FieldsFromForm(form)
 
-    if (!newFields.supervisedInCommunity) {
-      form.querySelector('input[name="supervised_in_community"]')?.focus()
-      return
-    }
-
-    if (newFields.supervisedInCommunity === 'yes' && !isDateComplete(newFields.communityDate)) {
-      setPredictorsAssessmentSession({ ...getPredictorsAssessmentSession(), ...newFields })
-      setConditionalVisible(SUPERVISED_CONDITIONAL_ID, true)
+    if (!isDateComplete(newFields.communityDate)) {
       form.querySelector('#supervised-community-date-day')?.focus()
       return
     }

--- a/app/assets/javascripts/02/predictors-a5-page.js
+++ b/app/assets/javascripts/02/predictors-a5-page.js
@@ -22,7 +22,7 @@ import {
   getPredictorsAssessmentSession,
   setPredictorsAssessmentSession
 } from './predictors-assessment-session.js'
-import { restoreDateInputs, setConditionalVisible } from '../tiering-conditional-fields.js'
+import { restoreDateInputs, setConditionalVisible } from './predictors-conditional-fields.js'
 
 const RECENT_OFFENCE_CONDITIONAL_ID = 'conditional-offences-since-community-yes'
 

--- a/app/assets/javascripts/02/predictors-a7-page.js
+++ b/app/assets/javascripts/02/predictors-a7-page.js
@@ -4,7 +4,7 @@
 
 import { getPredictorsBackLinkHref } from './predictors-change-scroll.js'
 import { getPredictorsAssessmentSession, setPredictorsAssessmentSession } from './predictors-assessment-session.js'
-import { ensureOffenceSearchData } from '../tiering-offence-browse.js'
+import { ensureOffenceSearchData } from './predictors-offence-browse.js'
 import {
   getA7BackHref,
   getPostInterviewYesContinueHref,

--- a/app/assets/javascripts/02/predictors-a8-page.js
+++ b/app/assets/javascripts/02/predictors-a8-page.js
@@ -6,7 +6,7 @@ import { applySection1CompleteUi, markSection1Complete } from './assessment-sect
 import { formatToday } from './predictors-assessment-session.js'
 import { getPredictorsBackLinkHref } from './predictors-change-scroll.js'
 import { getDynamicPredictorsCheckAnswersHref, hasDynamicScoresOrigin, syncPredictorsSessionBeforeCheckAnswers, predictorsJourneyHref } from './predictors-journey.js'
-import { initTieringInactiveLinks } from '../tiering-inactive-links.js'
+import { initPredictorsInactiveLinks } from './predictors-inactive-links.js'
 
 const scrollA8ToTop = () => {
   window.scrollTo({ top: 0, left: 0, behavior: 'instant' })
@@ -119,7 +119,7 @@ window.GOVUKPrototypeKit.documentReady(() => {
   initCompletionDate()
   applyRiskPredictorScoreTypeTags(session)
   applySexualPredictorEmptyStates(session)
-  initTieringInactiveLinks()
+  initPredictorsInactiveLinks()
   initRiskPredictorBackToTop()
 
   const markCompleteButton = document.getElementById('predictors-mark-section-complete')

--- a/app/assets/javascripts/02/predictors-assessment-session.js
+++ b/app/assets/javascripts/02/predictors-assessment-session.js
@@ -161,7 +161,3 @@ export const getOffenderDateOfBirthParts = () => {
 
   return { ...OFFENDER_DATE_OF_BIRTH_PARTS }
 }
-
-// Shared script compatibility (offence-search, conviction-date, etc.)
-export const getTieringAssessmentSession = getPredictorsAssessmentSession
-export const setTieringAssessmentSession = setPredictorsAssessmentSession

--- a/app/assets/javascripts/02/predictors-b11-page.js
+++ b/app/assets/javascripts/02/predictors-b11-page.js
@@ -4,7 +4,7 @@
 
 import { getPredictorsBackLinkHref, PREDICTORS_FROM_B11_DYNAMIC, PREDICTORS_FROM_B11_STATIC } from './predictors-change-scroll.js'
 import { setPredictorsAssessmentSession } from './predictors-assessment-session.js'
-import { ensureOffenceSearchData } from '../tiering-offence-browse.js'
+import { ensureOffenceSearchData } from './predictors-offence-browse.js'
 import {
   getB11BackHref,
   getPredictorsResultsScoresHref,

--- a/app/assets/javascripts/02/predictors-change-scroll.js
+++ b/app/assets/javascripts/02/predictors-change-scroll.js
@@ -393,7 +393,3 @@ window.GOVUKPrototypeKit.documentReady(() => {
 
   scrollToPredictorsChangeTarget()
 })
-
-// Shared script compatibility (offence-search, conviction-date, etc.)
-export const isTieringCheckAnswersEdit = isPredictorsCheckAnswersEdit
-export const TIERING_CHANGE_ANCHORS = PREDICTORS_CHANGE_ANCHORS

--- a/app/assets/javascripts/02/predictors-dynamic-summary.js
+++ b/app/assets/javascripts/02/predictors-dynamic-summary.js
@@ -9,6 +9,7 @@ const formatYesNo = (value) => {
   if (!value) return null
   if (value === 'yes') return 'Yes'
   if (value === 'no') return 'No'
+  if (value === 'unknown') return 'Unknown'
   return value
 }
 
@@ -30,7 +31,8 @@ const formatCheckboxLabels = (values, labelMap) => {
 const ACCOMMODATION_LABELS = {
   yes: 'Yes',
   'yes-with-concerns': 'Yes, with concerns',
-  no: 'No'
+  no: 'No',
+  unknown: 'Unknown'
 }
 
 const EMPLOYMENT_LABELS = {
@@ -43,7 +45,8 @@ const EMPLOYMENT_LABELS = {
 const ALCOHOL_USE_LABELS = {
   'yes-in-last-3-months': 'Yes, including in the last 3 months',
   'yes-not-in-last-3-months': 'Yes, but not in the last 3 months',
-  no: 'No'
+  no: 'No',
+  unknown: 'Unknown'
 }
 
 const ALCOHOL_FREQUENCY_LABELS = {
@@ -72,7 +75,8 @@ const RELATIONSHIP_STATUS_LABELS = {
     'Happy and positive about their relationship status, or their relationship is likely to act as a protective factor',
   'some-concerns': 'Has some concerns about their relationship status but is overall happy',
   'unhappy-unhealthy':
-    'Unhappy about their relationship status, or their relationship is unhealthy and directly linked to offending'
+    'Unhappy about their relationship status, or their relationship is unhealthy and directly linked to offending',
+  unknown: 'Unknown'
 }
 
 const ACTIVITIES_LINKED_LABELS = {
@@ -81,27 +85,31 @@ const ACTIVITIES_LINKED_LABELS = {
   'sometimes-linked-recognises':
     'Sometimes engages in activities linked to offending but recognises the link',
   'regularly-encourages-unaware':
-    'Regularly engages in activities which encourage offending and is not aware or does not care about the link to offending'
+    'Regularly engages in activities which encourage offending and is not aware or does not care about the link to offending',
+  unknown: 'Unknown'
 }
 
 const MANAGE_TEMPER_LABELS = {
   'manages-well': 'Yes, is able to manage their temper well',
   'sometimes-uncontrolled-anger': 'Sometimes has outbreaks of uncontrolled anger',
-  'easily-loses-temper': 'No, easily loses their temper'
+  'easily-loses-temper': 'No, easily loses their temper',
+  unknown: 'Unknown'
 }
 
 const ACT_ON_IMPULSE_LABELS = {
   'considers-before-acting':
     'Considers all aspects of a situation before acting on or making a decision',
   'sometimes-causes-problems': 'Sometimes acts on impulse which causes problems',
-  'significant-problems': 'Acts on impulse which causes significant problems'
+  'significant-problems': 'Acts on impulse which causes significant problems',
+  unknown: 'Unknown'
 }
 
 const SUPPORT_CRIMINAL_BEHAVIOUR_LABELS = {
   'does-not-support': 'Does not support or excuse criminal behaviour',
   'sometimes-supports': 'Sometimes supports or excuses criminal behaviour',
   'supports-or-excuses-issue':
-    'Supports or excuses criminal behaviour or their pattern of behaviour and other evidence indicates this is an issue'
+    'Supports or excuses criminal behaviour or their pattern of behaviour and other evidence indicates this is an issue',
+  unknown: 'Unknown'
 }
 
 const DOMESTIC_ABUSE_RELATION_LABELS = {

--- a/app/assets/javascripts/02/predictors-inactive-links.js
+++ b/app/assets/javascripts/02/predictors-inactive-links.js
@@ -14,7 +14,7 @@ export const markPrototypeOnlyLink = (link) => {
   }
 }
 
-export const initTieringInactiveLinks = (root = document) => {
+export const initPredictorsInactiveLinks = (root = document) => {
   root.querySelectorAll('[data-predictors-inactive-link]').forEach((link) => {
     markPrototypeOnlyLink(link)
     link.addEventListener('click', (event) => {

--- a/app/assets/javascripts/02/predictors-journey.js
+++ b/app/assets/javascripts/02/predictors-journey.js
@@ -11,7 +11,7 @@ import {
   getPredictorsAssessmentSession,
   setPredictorsAssessmentSession
 } from './predictors-assessment-session.js'
-import { lookupOffenceDetails } from '../tiering-offence-browse.js'
+import { lookupOffenceDetails } from './predictors-offence-browse.js'
 import {
   getMisusedDrugConditionalId,
   MISUSED_DRUG_TYPES
@@ -194,7 +194,9 @@ export const PROTOTYPE_DEFAULT_CURRENT_OFFENCE = {
   isViolentOffence: true
 }
 
-const PROTOTYPE_DEFAULT_COMMUNITY_DATE = { day: '24', month: '7', year: '2026' }
+const PROTOTYPE_DEFAULT_COMMUNITY_DATE = { day: '2', month: '5', year: '2015' }
+
+export const getDefaultCommunityDateParts = () => ({ ...PROTOTYPE_DEFAULT_COMMUNITY_DATE })
 
 const getDefaultRecentOffenceDateParts = () => {
   const date = new Date()
@@ -302,11 +304,10 @@ export const syncPredictorsSessionBeforeCheckAnswers = () => {
   }
 
   if (!session.supervisedInCommunity) {
-    updates.supervisedInCommunity = 'no'
+    updates.supervisedInCommunity = 'yes'
   }
 
-  const supervisedInCommunity = updates.supervisedInCommunity || session.supervisedInCommunity
-  if (supervisedInCommunity === 'yes' && !isDateComplete(session.communityDate)) {
+  if (!isDateComplete(session.communityDate)) {
     updates.communityDate = { ...PROTOTYPE_DEFAULT_COMMUNITY_DATE }
   }
 
@@ -390,7 +391,7 @@ export const clearA5SessionFields = () => ({
   recentOffenceDate: { day: '', month: '', year: '' }
 })
 
-export const isA5Required = (session) => session.supervisedInCommunity === 'yes'
+export const isA5Required = (session) => isDateComplete(session.communityDate)
 
 export const getPostA4ContinueHref = (session = getPredictorsAssessmentSession()) =>
   isA5Required(session) ? 'a5.html' : 'a6.html'
@@ -447,11 +448,7 @@ export const isA2Complete = (session) =>
       session.sexualOffence
   )
 
-export const isA4Complete = (session) =>
-  Boolean(
-    session.supervisedInCommunity &&
-      (session.supervisedInCommunity !== 'yes' || isDateComplete(session.communityDate))
-  )
+export const isA4Complete = (session) => isDateComplete(session.communityDate)
 
 export const getFirstIncompletePredictorsPage = (session) => {
   if (!session.currentOffence?.id) return 'a1.html'
@@ -492,14 +489,6 @@ export const applyBranchingCleanup = (currentPage, session, updates) => {
     return { ...merged, ...clearA3SessionFields() }
   }
 
-  if (currentPage === 'a4' && merged.supervisedInCommunity !== 'yes') {
-    return {
-      ...merged,
-      communityDate: { day: '', month: '', year: '' },
-      ...clearA5SessionFields()
-    }
-  }
-
   if (currentPage === 'a5' && merged.offencesSinceCommunity !== 'yes') {
     return { ...merged, ...clearA6SessionFields() }
   }
@@ -526,7 +515,7 @@ export const applyBranchingCleanup = (currentPage, session, updates) => {
     return { ...merged, ...clearB4SessionFields() }
   }
 
-  if (currentPage === 'b5' && merged.alcoholUse === 'no') {
+  if (currentPage === 'b5' && (merged.alcoholUse === 'no' || merged.alcoholUse === 'unknown')) {
     return { ...merged, ...clearB6SessionFields() }
   }
 
@@ -582,15 +571,6 @@ export const getCheckAnswersReturnHrefAfterEdit = (
  * changes that open a new required page — not for simple field updates (e.g. a4 date).
  */
 export const getContinueHrefAfterCheckAnswersEdit = (currentPage, beforeSession, afterSession) => {
-  if (currentPage === 'a4') {
-    const beforeRequiredA5 = beforeSession.supervisedInCommunity === 'yes'
-    const afterRequiredA5 = afterSession.supervisedInCommunity === 'yes'
-
-    if (beforeRequiredA5 !== afterRequiredA5) {
-      return getFirstIncompletePredictorsPage(afterSession)
-    }
-  }
-
   if (currentPage === 'a2' && afterSession.sexualOffence === 'yes' && !isA3Complete(afterSession)) {
     return getFirstIncompleteA3Page(afterSession) || 'a3.html'
   }
@@ -692,26 +672,14 @@ export const getA3FieldsFromForm = (form) => ({
   ...getA3IndirectContactFieldsFromForm(form)
 })
 
-export const getA4FieldsFromForm = (form) => {
-  const supervisedInCommunity =
-    form.querySelector('input[name="supervised_in_community"]:checked')?.value || ''
-
-  if (supervisedInCommunity === 'no') {
-    return {
-      supervisedInCommunity,
-      communityDate: { day: '', month: '', year: '' }
-    }
-  }
-
-  return {
-    supervisedInCommunity,
-    communityDate: normaliseDateParts({
-      day: form.querySelector('#supervised-community-date-day')?.value,
-      month: form.querySelector('#supervised-community-date-month')?.value,
-      year: form.querySelector('#supervised-community-date-year')?.value
-    })
-  }
-}
+export const getA4FieldsFromForm = (form) => ({
+  supervisedInCommunity: 'yes',
+  communityDate: normaliseDateParts({
+    day: form.querySelector('#supervised-community-date-day')?.value,
+    month: form.querySelector('#supervised-community-date-month')?.value,
+    year: form.querySelector('#supervised-community-date-year')?.value
+  })
+})
 
 export const getA5FieldsFromForm = (form) => ({
   offencesSinceCommunity: form.querySelector('input[name="offences_since_community"]:checked')?.value || '',
@@ -848,7 +816,7 @@ export const getPostB5ContinueHref = (session = getPredictorsAssessmentSession()
 
 export const getFirstIncompleteAlcoholPage = (session = getPredictorsAssessmentSession()) => {
   if (!session.alcoholUse) return 'b5.html'
-  if (session.alcoholUse === 'no') return null
+  if (session.alcoholUse === 'no' || session.alcoholUse === 'unknown') return null
 
   if (session.alcoholUse === 'yes-in-last-3-months') {
     if (!session.alcoholFrequencyLast3Months || !session.alcoholUnitsTypicalDay || !session.alcoholBingeEvidence) {
@@ -878,7 +846,7 @@ export const getPostB9ContinueHref = () => 'b10.html'
 export const getPostB10ContinueHref = () => 'b11.html'
 
 export const isAlcoholSectionComplete = (session = getPredictorsAssessmentSession()) => {
-  if (session.alcoholUse === 'no') return true
+  if (session.alcoholUse === 'no' || session.alcoholUse === 'unknown') return true
 
   if (session.alcoholUse === 'yes-not-in-last-3-months') {
     return Boolean(session.alcoholBingeEvidence)
@@ -1248,11 +1216,8 @@ export const getUnansweredPredictorsQuestions = (session, offenderFirstName = 'A
     add(
       'a4',
       'Community supervision',
-      `Is ${name} currently being supervised in the community?`
+      `What date did ${name}'s current supervision in the community begin?`
     )
-    if (session.supervisedInCommunity === 'yes' && !isDateComplete(session.communityDate)) {
-      add('a4', 'Community supervision', `What date did ${name}'s supervision begin?`)
-    }
   }
 
   if (isA5Required(session) && !session.offencesSinceCommunity) {

--- a/app/assets/javascripts/02/predictors-offence-browse.js
+++ b/app/assets/javascripts/02/predictors-offence-browse.js
@@ -57,12 +57,55 @@ export const formatOffenceLabelWithCodes = (offence) => {
   return codeBracket ? `${offence.label}  ${codeBracket}` : offence.label
 }
 
+const normaliseOffenceId = (offenceId) => String(offenceId ?? '').trim().toLowerCase()
+
+export const ensureOffenceSearchData = async () => {
+  if (window.OFFENCE_SEARCH_DATA?.length) return window.OFFENCE_SEARCH_DATA
+
+  try {
+    const response = await fetch('/api/offences')
+    if (!response.ok) return []
+    window.OFFENCE_SEARCH_DATA = await response.json()
+    return window.OFFENCE_SEARCH_DATA
+  } catch {
+    return []
+  }
+}
+
+export const lookupOffenceDetails = (offenceId) => {
+  const offences = window.OFFENCE_SEARCH_DATA
+  if (!offences?.length || !offenceId) return null
+
+  const targetId = normaliseOffenceId(offenceId)
+
+  for (const group of offences) {
+    const match = (group.subOffences || []).find((sub) => normaliseOffenceId(sub.id) === targetId)
+    if (match) {
+      return {
+        id: match.id,
+        label: match.label || '',
+        code: match.code || '',
+        subcode: match.subcode || '',
+        fullCode: match.fullCode || '',
+        parentGroupDescription: group.category || '',
+        categoryDescription: group.label || '',
+        subCategoryDescription: match.description || match.label || '',
+        isViolentOffence: Boolean(match.isViolentOffence)
+      }
+    }
+  }
+
+  return null
+}
+
 export const lookupOffenceIsViolent = (offenceId) => {
   const offences = window.OFFENCE_SEARCH_DATA
   if (!offences?.length || !offenceId) return false
 
+  const targetId = normaliseOffenceId(offenceId)
+
   for (const group of offences) {
-    const match = (group.subOffences || []).find((sub) => sub.id === offenceId)
+    const match = (group.subOffences || []).find((sub) => normaliseOffenceId(sub.id) === targetId)
     if (match) return Boolean(match.isViolentOffence)
   }
 

--- a/app/assets/javascripts/02/predictors-skip-to-end.js
+++ b/app/assets/javascripts/02/predictors-skip-to-end.js
@@ -39,8 +39,10 @@ window.GOVUKPrototypeKit.documentReady(async () => {
     indirectChildSanctions: '1',
     nonContactSanctions: '1',
 
-    // a4 (no path skips a5)
-    supervisedInCommunity: 'no',
+    // a4 + a5
+    supervisedInCommunity: 'yes',
+    communityDate: { day: '2', month: '5', year: '2015' },
+    offencesSinceCommunity: 'no',
 
     // state
     scoreCalculated: true,

--- a/app/assets/javascripts/02/predictors-summary.js
+++ b/app/assets/javascripts/02/predictors-summary.js
@@ -181,24 +181,6 @@ export const buildPredictorsSummarySections = (session, offenderFirstName = 'Ale
         false,
         PREDICTORS_CHANGE_ANCHORS.convictionDate,
         true
-      ),
-      createRow(
-        'Offence code',
-        offenceCodeLabel || null,
-        'a1.html',
-        'Offence code',
-        false,
-        TIERING_CHANGE_ANCHORS.currentOffence,
-        true
-      ),
-      createRow(
-        'Date of current conviction',
-        convictionDateLabel || null,
-        'a1.html',
-        'Date of current conviction',
-        false,
-        TIERING_CHANGE_ANCHORS.convictionDate,
-        true
       )
     ]
   })
@@ -243,7 +225,7 @@ export const buildPredictorsSummarySections = (session, offenderFirstName = 'Ale
 
   if (session.sexualOffence === 'yes') {
     sections.push({
-      title: 'Sexual or sexually motivated offending',
+      title: 'Current and recent sexual offending',
       rows: [
         createRow(
           `Does ${name}'s current offence have a sexual motivation?`,
@@ -317,33 +299,18 @@ export const buildPredictorsSummarySections = (session, offenderFirstName = 'Ale
     })
   }
 
-  const communitySupervisionRows = [
-    createRow(
-      `Is ${name} currently being supervised in the community?`,
-      formatChoice(session.supervisedInCommunity),
-      'a4.html',
-      `Is ${name} currently being supervised in the community?`,
-      false,
-      PREDICTORS_CHANGE_ANCHORS.supervisedInCommunity
-    )
-  ]
-
-  if (session.supervisedInCommunity === 'yes') {
-    communitySupervisionRows.push(
+  sections.push({
+    title: 'Community supervision',
+    rows: [
       createRow(
-        `What date did ${name}'s supervision begin?`,
+        `What date did ${name}'s current supervision in the community begin?`,
         formatDateFromParts(session.communityDate || {}),
         'a4.html',
-        `What date did ${name}'s supervision begin?`,
+        `What date did ${name}'s current supervision in the community begin?`,
         false,
         PREDICTORS_CHANGE_ANCHORS.supervisedCommunityDate
       )
-    )
-  }
-
-  sections.push({
-    title: 'Community supervision',
-    rows: communitySupervisionRows
+    ]
   })
 
   const communityDateLabel = formatDateFromParts(session.communityDate || {}) || 'that date'

--- a/app/assets/javascripts/a2b-current-offence-toggle.js
+++ b/app/assets/javascripts/a2b-current-offence-toggle.js
@@ -1,0 +1,67 @@
+//
+// a2b – toggle current offence section between default and highlighted inset
+//
+
+const STORAGE_KEY = 'predictors-a2b-current-offence-variant'
+const VARIANTS = ['default', 'highlighted']
+
+const isInteractiveTarget = (target) =>
+  Boolean(
+    target.closest(
+      'a, button, input, label, select, textarea, summary, [data-offence-search-input], [data-offence-search-submit]'
+    )
+  )
+
+const getStoredVariant = () => {
+  const stored = sessionStorage.getItem(STORAGE_KEY)
+  return VARIANTS.includes(stored) ? stored : 'default'
+}
+
+const setStoredVariant = (variant) => {
+  sessionStorage.setItem(STORAGE_KEY, variant)
+}
+
+const applyVariant = (root, variant) => {
+  const panel = root.querySelector('[data-a2b-current-offence-panel]')
+  const notice = root.querySelector('[data-a2b-current-offence-notice]')
+  if (!panel || !notice) return
+
+  root.dataset.a2bCurrentOffenceVariant = variant
+  root.setAttribute('aria-pressed', String(variant === 'highlighted'))
+
+  panel.classList.toggle('govuk-inset-text', variant === 'highlighted')
+  panel.classList.toggle('guidance-panel', variant === 'highlighted')
+  panel.classList.toggle('govuk-!-margin-0', variant === 'highlighted')
+
+  notice.classList.toggle('govuk-inset-text', variant === 'default')
+  notice.classList.toggle('a2b-current-offence__notice--plain', variant === 'highlighted')
+}
+
+const cycleVariant = (root) => {
+  const next = getStoredVariant() === 'highlighted' ? 'default' : 'highlighted'
+  setStoredVariant(next)
+  applyVariant(root, next)
+}
+
+export const initA2bCurrentOffenceToggle = () => {
+  const root = document.querySelector('[data-a2b-current-offence]')
+  if (!root) return
+
+  root.setAttribute('role', 'button')
+  root.setAttribute('tabindex', '0')
+  root.setAttribute('aria-label', 'Toggle current offence layout')
+
+  applyVariant(root, getStoredVariant())
+
+  root.addEventListener('click', (event) => {
+    if (isInteractiveTarget(event.target)) return
+    cycleVariant(root)
+  })
+
+  root.addEventListener('keydown', (event) => {
+    if (event.key !== 'Enter' && event.key !== ' ') return
+    if (isInteractiveTarget(event.target)) return
+    event.preventDefault()
+    cycleVariant(root)
+  })
+}

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -33,6 +33,7 @@ import './02/predictors-a1os-page.js'
 import './02/predictors-a1o3-page.js'
 import './02/predictors-a1r-page.js'
 import './02/predictors-a2-page.js'
+import './02/predictors-a2b-page.js'
 import './02/predictors-a3-page.js'
 import './02/predictors-a4-page.js'
 import './02/predictors-a5-page.js'
@@ -59,6 +60,7 @@ import './dev/predictors-a1os-page.js'
 import './dev/predictors-a1o3-page.js'
 import './dev/predictors-a1r-page.js'
 import './dev/predictors-a2-page.js'
+import './dev/predictors-a2b-page.js'
 import './dev/predictors-a3-page.js'
 import './dev/predictors-a4-page.js'
 import './dev/predictors-a5-page.js'
@@ -74,6 +76,8 @@ import './tiering-change-scroll.js'
 import { initPreserveConditionalFieldValues } from './tiering-conditional-fields.js'
 import { initTieringInactiveLinks } from './tiering-inactive-links.js'
 import { initB6LayoutToggleButtons } from './02/predictors-b6-layout-toggle.js'
+import { initA2LayoutToggleButtons } from './02/predictors-a2-layout-toggle.js'
+import { initA1LayoutToggleButtons } from './02/predictors-a1-layout-toggle.js'
 import { initA1SourceNoticeToggle } from './tiering-a1-source-notice-toggle.js'
 import { initB1CaptionProgressToggle } from './tiering-b1-caption-progress-toggle.js'
 
@@ -81,6 +85,8 @@ window.GOVUKPrototypeKit.documentReady(() => {
   initPreserveConditionalFieldValues()
   initTieringInactiveLinks()
   initB6LayoutToggleButtons()
+  initA2LayoutToggleButtons()
+  initA1LayoutToggleButtons()
   initA1SourceNoticeToggle()
   initB1CaptionProgressToggle()
 })

--- a/app/assets/javascripts/dev/predictors-a2b-page.js
+++ b/app/assets/javascripts/dev/predictors-a2b-page.js
@@ -1,0 +1,94 @@
+//
+// a2b – current offence + offending history (merged a1 + a2)
+//
+
+import {
+  initConvictionDate,
+  isConvictionDateEditPanelOpen,
+  persistConvictionDateState
+} from '../conviction-date.js'
+import {
+  getDefaultFirstSanctionDateParts,
+  getPredictorsAssessmentSession
+} from './predictors-assessment-session.js'
+import {
+  captureCheckAnswersEditSnapshot,
+  completePredictorsPageAndContinue,
+  isPredictorsCheckAnswersEdit
+} from './predictors-change-scroll.js'
+import { initA1OffenceDisplayToggle } from '../tiering-a1-display-toggle.js'
+import { initA2bCurrentOffenceToggle } from '../a2b-current-offence-toggle.js'
+import { getA1FieldsFromForm, getA2FieldsFromForm } from './predictors-journey.js'
+
+const setFirstSanctionDateValues = (parts) => {
+  const dayInput = document.getElementById('first-sanction-date-day')
+  const monthInput = document.getElementById('first-sanction-date-month')
+  const yearInput = document.getElementById('first-sanction-date-year')
+
+  if (dayInput) dayInput.value = parts.day || ''
+  if (monthInput) monthInput.value = parts.month || ''
+  if (yearInput) yearInput.value = parts.year || ''
+}
+
+window.GOVUKPrototypeKit.documentReady(() => {
+  if (!window.location.pathname.includes('/dev/')) return
+
+  const form = document.getElementById('predictors-a2b-form')
+  if (!form) return
+
+  initConvictionDate()
+  initA1OffenceDisplayToggle()
+  initA2bCurrentOffenceToggle()
+
+  document.querySelector('[data-predictors-offence-browse-link]')?.addEventListener('click', () => {
+    persistConvictionDateState({ editing: isConvictionDateEditPanelOpen() })
+  })
+
+  const session = getPredictorsAssessmentSession()
+
+  if (session.firstSanctionDate) {
+    setFirstSanctionDateValues(session.firstSanctionDate)
+  } else {
+    setFirstSanctionDateValues(getDefaultFirstSanctionDateParts())
+  }
+
+  if (session.totalSanctions) {
+    const totalSanctions = form.querySelector('#total-sanctions')
+    if (totalSanctions) totalSanctions.value = session.totalSanctions
+  }
+  if (session.violentSanctions) {
+    const violentSanctions = form.querySelector('#violent-sanctions-other')
+    if (violentSanctions) violentSanctions.value = session.violentSanctions
+  }
+  if (session.sexualOffence) {
+    const sexualOffenceInput = form.querySelector(
+      `input[name="sexual_offence"][value="${session.sexualOffence}"]`
+    )
+    if (sexualOffenceInput) sexualOffenceInput.checked = true
+  }
+
+  if (isPredictorsCheckAnswersEdit()) {
+    captureCheckAnswersEditSnapshot({
+      ...getA1FieldsFromForm(form),
+      ...getA2FieldsFromForm(form)
+    })
+  }
+
+  form.addEventListener('submit', (event) => {
+    event.preventDefault()
+
+    const newFields = {
+      ...getA1FieldsFromForm(form),
+      ...getA2FieldsFromForm(form),
+      convictionDateEditMode: false
+    }
+
+    const sexualOffence = newFields.sexualOffence
+
+    window.location.href = completePredictorsPageAndContinue(
+      'a2',
+      sexualOffence === 'yes' ? 'a3.html' : 'a4.html',
+      newFields
+    )
+  })
+})

--- a/app/assets/javascripts/dev/predictors-a3-page.js
+++ b/app/assets/javascripts/dev/predictors-a3-page.js
@@ -11,7 +11,7 @@ import {
 } from './predictors-change-scroll.js'
 import { getA3FieldsFromForm, isA3Complete } from './predictors-journey.js'
 import { getPredictorsAssessmentSession } from './predictors-assessment-session.js'
-import { initTieringInactiveLinks } from '../tiering-inactive-links.js'
+import { initPredictorsInactiveLinks } from './predictors-inactive-links.js'
 
 const restoreRadio = (form, name, value) => {
   if (!value) return
@@ -88,7 +88,7 @@ window.GOVUKPrototypeKit.documentReady(() => {
     return
   }
 
-  initTieringInactiveLinks(form)
+  initPredictorsInactiveLinks(form)
 
   const shouldRestoreSavedAnswers =
     isPredictorsCheckAnswersEdit() || isPredictorsBackNavigation() || isA3Complete(session)

--- a/app/assets/javascripts/dev/predictors-a4-page.js
+++ b/app/assets/javascripts/dev/predictors-a4-page.js
@@ -1,5 +1,5 @@
 //
-// a4 – community supervision and date
+// a4 – community supervision start date
 //
 
 import {
@@ -10,11 +10,15 @@ import {
   scrollToPredictorsChangeTarget,
   PREDICTORS_CHANGE_ANCHORS
 } from './predictors-change-scroll.js'
-import { restoreDateInputs, setConditionalVisible } from '../tiering-conditional-fields.js'
-import { getA4FieldsFromForm, getFirstIncompleteA3Page, getPostA4ContinueHref, isDateComplete } from './predictors-journey.js'
-import { getPredictorsAssessmentSession, setPredictorsAssessmentSession } from './predictors-assessment-session.js'
-
-const SUPERVISED_CONDITIONAL_ID = 'conditional-supervised-in-community-yes'
+import { restoreDateInputs } from './predictors-conditional-fields.js'
+import {
+  getA4FieldsFromForm,
+  getDefaultCommunityDateParts,
+  getFirstIncompleteA3Page,
+  getPostA4ContinueHref,
+  isDateComplete
+} from './predictors-journey.js'
+import { getPredictorsAssessmentSession } from './predictors-assessment-session.js'
 
 const getA4BackHref = (session) => {
   if (session.sexualOffence !== 'yes') return 'a2.html'
@@ -34,29 +38,22 @@ window.GOVUKPrototypeKit.documentReady(() => {
     backLink.href = getPredictorsBackLinkHref(getA4BackHref(session))
   }
 
-  if (session.supervisedInCommunity) {
-    const input = form.querySelector(
-      `input[name="supervised_in_community"][value="${session.supervisedInCommunity}"]`
-    )
-    if (input) input.checked = true
-  }
+  const communityDate = isDateComplete(session.communityDate)
+    ? session.communityDate
+    : getDefaultCommunityDateParts()
 
-  const hashTarget = window.location.hash.slice(1)
-  const supervisedInCommunity = session.supervisedInCommunity
-  const showSupervisedDate =
-    supervisedInCommunity === 'yes' || hashTarget === PREDICTORS_CHANGE_ANCHORS.supervisedCommunityDate
-
-  if (showSupervisedDate) {
-    setConditionalVisible(SUPERVISED_CONDITIONAL_ID, true)
-    restoreDateInputs(form, 'supervised-community-date', session.communityDate)
-  }
+  restoreDateInputs(form, 'supervised-community-date', communityDate)
 
   if (isPredictorsCheckAnswersEdit()) {
     captureCheckAnswersEditSnapshot(getA4FieldsFromForm(form))
   }
 
-  if (hashTarget === PREDICTORS_CHANGE_ANCHORS.supervisedInCommunity || hashTarget === PREDICTORS_CHANGE_ANCHORS.supervisedCommunityDate) {
-    scrollToPredictorsChangeTarget(hashTarget)
+  const hashTarget = window.location.hash.slice(1)
+  if (
+    hashTarget === PREDICTORS_CHANGE_ANCHORS.supervisedCommunityDate ||
+    hashTarget === PREDICTORS_CHANGE_ANCHORS.supervisedInCommunity
+  ) {
+    scrollToPredictorsChangeTarget(PREDICTORS_CHANGE_ANCHORS.supervisedCommunityDate)
   }
 
   form.addEventListener('submit', (event) => {
@@ -64,14 +61,7 @@ window.GOVUKPrototypeKit.documentReady(() => {
 
     const newFields = getA4FieldsFromForm(form)
 
-    if (!newFields.supervisedInCommunity) {
-      form.querySelector('input[name="supervised_in_community"]')?.focus()
-      return
-    }
-
-    if (newFields.supervisedInCommunity === 'yes' && !isDateComplete(newFields.communityDate)) {
-      setPredictorsAssessmentSession({ ...getPredictorsAssessmentSession(), ...newFields })
-      setConditionalVisible(SUPERVISED_CONDITIONAL_ID, true)
+    if (!isDateComplete(newFields.communityDate)) {
       form.querySelector('#supervised-community-date-day')?.focus()
       return
     }

--- a/app/assets/javascripts/dev/predictors-a5-page.js
+++ b/app/assets/javascripts/dev/predictors-a5-page.js
@@ -22,7 +22,7 @@ import {
   getPredictorsAssessmentSession,
   setPredictorsAssessmentSession
 } from './predictors-assessment-session.js'
-import { restoreDateInputs, setConditionalVisible } from '../tiering-conditional-fields.js'
+import { restoreDateInputs, setConditionalVisible } from './predictors-conditional-fields.js'
 
 const RECENT_OFFENCE_CONDITIONAL_ID = 'conditional-offences-since-community-yes'
 

--- a/app/assets/javascripts/dev/predictors-a7-page.js
+++ b/app/assets/javascripts/dev/predictors-a7-page.js
@@ -4,7 +4,7 @@
 
 import { getPredictorsBackLinkHref } from './predictors-change-scroll.js'
 import { setPredictorsAssessmentSession } from './predictors-assessment-session.js'
-import { ensureOffenceSearchData } from '../tiering-offence-browse.js'
+import { ensureOffenceSearchData } from './predictors-offence-browse.js'
 import {
   getA7BackHref,
   getPredictorsResultsScoresHref,

--- a/app/assets/javascripts/dev/predictors-a8-page.js
+++ b/app/assets/javascripts/dev/predictors-a8-page.js
@@ -5,7 +5,7 @@
 import { markSection1Complete } from './assessment-section-complete.js'
 import { getPredictorsBackLinkHref } from './predictors-change-scroll.js'
 import { syncPredictorsSessionBeforeCheckAnswers, predictorsJourneyHref } from './predictors-journey.js'
-import { initTieringInactiveLinks } from '../tiering-inactive-links.js'
+import { initPredictorsInactiveLinks } from './predictors-inactive-links.js'
 
 const scrollA8ToTop = () => {
   window.scrollTo({ top: 0, left: 0, behavior: 'instant' })
@@ -77,7 +77,7 @@ window.GOVUKPrototypeKit.documentReady(() => {
   }
 
   applySexualPredictorEmptyStates(session)
-  initTieringInactiveLinks()
+  initPredictorsInactiveLinks()
   initRiskPredictorBackToTop()
 
   const markCompleteButton = document.getElementById('predictors-mark-section-complete')

--- a/app/assets/javascripts/dev/predictors-assessment-session.js
+++ b/app/assets/javascripts/dev/predictors-assessment-session.js
@@ -161,7 +161,3 @@ export const getOffenderDateOfBirthParts = () => {
 
   return { ...OFFENDER_DATE_OF_BIRTH_PARTS }
 }
-
-// Shared script compatibility (offence-search, conviction-date, etc.)
-export const getTieringAssessmentSession = getPredictorsAssessmentSession
-export const setTieringAssessmentSession = setPredictorsAssessmentSession

--- a/app/assets/javascripts/dev/predictors-change-scroll.js
+++ b/app/assets/javascripts/dev/predictors-change-scroll.js
@@ -261,7 +261,3 @@ window.GOVUKPrototypeKit.documentReady(() => {
 
   scrollToPredictorsChangeTarget()
 })
-
-// Shared script compatibility (offence-search, conviction-date, etc.)
-export const isTieringCheckAnswersEdit = isPredictorsCheckAnswersEdit
-export const TIERING_CHANGE_ANCHORS = PREDICTORS_CHANGE_ANCHORS

--- a/app/assets/javascripts/dev/predictors-inactive-links.js
+++ b/app/assets/javascripts/dev/predictors-inactive-links.js
@@ -16,7 +16,7 @@ export const markPrototypeOnlyLink = (link) => {
 
 const isDevProtoPage = () => window.location.pathname.includes('/dev/')
 
-export const initTieringInactiveLinks = (root = document) => {
+export const initPredictorsInactiveLinks = (root = document) => {
   root.querySelectorAll('[data-predictors-inactive-link]').forEach((link) => {
     markPrototypeOnlyLink(link)
     link.addEventListener('click', (event) => {

--- a/app/assets/javascripts/dev/predictors-journey.js
+++ b/app/assets/javascripts/dev/predictors-journey.js
@@ -11,7 +11,7 @@ import {
   getPredictorsAssessmentSession,
   setPredictorsAssessmentSession
 } from './predictors-assessment-session.js'
-import { lookupOffenceDetails } from '../tiering-offence-browse.js'
+import { lookupOffenceDetails } from './predictors-offence-browse.js'
 
 const PREDICTORS_JOURNEY_PATH = '/dev/'
 
@@ -190,7 +190,9 @@ export const PROTOTYPE_DEFAULT_CURRENT_OFFENCE = {
   isViolentOffence: true
 }
 
-const PROTOTYPE_DEFAULT_COMMUNITY_DATE = { day: '24', month: '7', year: '2026' }
+const PROTOTYPE_DEFAULT_COMMUNITY_DATE = { day: '2', month: '5', year: '2015' }
+
+export const getDefaultCommunityDateParts = () => ({ ...PROTOTYPE_DEFAULT_COMMUNITY_DATE })
 
 const getDefaultRecentOffenceDateParts = () => {
   const date = new Date()
@@ -298,11 +300,10 @@ export const syncPredictorsSessionBeforeCheckAnswers = () => {
   }
 
   if (!session.supervisedInCommunity) {
-    updates.supervisedInCommunity = 'no'
+    updates.supervisedInCommunity = 'yes'
   }
 
-  const supervisedInCommunity = updates.supervisedInCommunity || session.supervisedInCommunity
-  if (supervisedInCommunity === 'yes' && !isDateComplete(session.communityDate)) {
+  if (!isDateComplete(session.communityDate)) {
     updates.communityDate = { ...PROTOTYPE_DEFAULT_COMMUNITY_DATE }
   }
 
@@ -374,7 +375,7 @@ export const clearA5SessionFields = () => ({
   recentOffenceDate: { day: '', month: '', year: '' }
 })
 
-export const isA5Required = (session) => session.supervisedInCommunity === 'yes'
+export const isA5Required = (session) => isDateComplete(session.communityDate)
 
 export const getPostA4ContinueHref = (session = getPredictorsAssessmentSession()) =>
   isA5Required(session) ? 'a5.html' : 'a6.html'
@@ -431,11 +432,7 @@ export const isA2Complete = (session) =>
       session.sexualOffence
   )
 
-export const isA4Complete = (session) =>
-  Boolean(
-    session.supervisedInCommunity &&
-      (session.supervisedInCommunity !== 'yes' || isDateComplete(session.communityDate))
-  )
+export const isA4Complete = (session) => isDateComplete(session.communityDate)
 
 export const getFirstIncompletePredictorsPage = (session) => {
   if (!session.currentOffence?.id) return 'a1.html'
@@ -478,14 +475,6 @@ export const applyBranchingCleanup = (currentPage, session, updates) => {
     return { ...merged, ...clearA3SessionFields() }
   }
 
-  if (currentPage === 'a4' && merged.supervisedInCommunity !== 'yes') {
-    return {
-      ...merged,
-      communityDate: { day: '', month: '', year: '' },
-      ...clearA5SessionFields()
-    }
-  }
-
   if (currentPage === 'a5' && merged.offencesSinceCommunity !== 'yes') {
     return { ...merged, ...clearA6SessionFields() }
   }
@@ -501,15 +490,6 @@ export const getPostCheckAnswersEditHref = (session) =>
  * changes that open a new required page — not for simple field updates (e.g. a4 date).
  */
 export const getContinueHrefAfterCheckAnswersEdit = (currentPage, beforeSession, afterSession) => {
-  if (currentPage === 'a4') {
-    const beforeRequiredA5 = beforeSession.supervisedInCommunity === 'yes'
-    const afterRequiredA5 = afterSession.supervisedInCommunity === 'yes'
-
-    if (beforeRequiredA5 !== afterRequiredA5) {
-      return getFirstIncompletePredictorsPage(afterSession)
-    }
-  }
-
   if (currentPage === 'a2' && afterSession.sexualOffence === 'yes' && !isA3Complete(afterSession)) {
     return getFirstIncompleteA3Page(afterSession) || 'a3.html'
   }
@@ -590,26 +570,14 @@ export const getA3FieldsFromForm = (form) => ({
   ...getA3IndirectContactFieldsFromForm(form)
 })
 
-export const getA4FieldsFromForm = (form) => {
-  const supervisedInCommunity =
-    form.querySelector('input[name="supervised_in_community"]:checked')?.value || ''
-
-  if (supervisedInCommunity === 'no') {
-    return {
-      supervisedInCommunity,
-      communityDate: { day: '', month: '', year: '' }
-    }
-  }
-
-  return {
-    supervisedInCommunity,
-    communityDate: normaliseDateParts({
-      day: form.querySelector('#supervised-community-date-day')?.value,
-      month: form.querySelector('#supervised-community-date-month')?.value,
-      year: form.querySelector('#supervised-community-date-year')?.value
-    })
-  }
-}
+export const getA4FieldsFromForm = (form) => ({
+  supervisedInCommunity: 'yes',
+  communityDate: normaliseDateParts({
+    day: form.querySelector('#supervised-community-date-day')?.value,
+    month: form.querySelector('#supervised-community-date-month')?.value,
+    year: form.querySelector('#supervised-community-date-year')?.value
+  })
+})
 
 export const getA5FieldsFromForm = (form) => ({
   offencesSinceCommunity: form.querySelector('input[name="offences_since_community"]:checked')?.value || '',
@@ -717,11 +685,8 @@ export const getUnansweredPredictorsQuestions = (session, offenderFirstName = 'A
     add(
       'a4',
       'Community supervision',
-      `Is ${name} currently being supervised in the community?`
+      `What date did ${name}'s current supervision in the community begin?`
     )
-    if (session.supervisedInCommunity === 'yes' && !isDateComplete(session.communityDate)) {
-      add('a4', 'Community supervision', `What date did ${name}'s supervision begin?`)
-    }
   }
 
   if (isA5Required(session) && !session.offencesSinceCommunity) {

--- a/app/assets/javascripts/dev/predictors-offence-browse.js
+++ b/app/assets/javascripts/dev/predictors-offence-browse.js
@@ -57,12 +57,55 @@ export const formatOffenceLabelWithCodes = (offence) => {
   return codeBracket ? `${offence.label}  ${codeBracket}` : offence.label
 }
 
+const normaliseOffenceId = (offenceId) => String(offenceId ?? '').trim().toLowerCase()
+
+export const ensureOffenceSearchData = async () => {
+  if (window.OFFENCE_SEARCH_DATA?.length) return window.OFFENCE_SEARCH_DATA
+
+  try {
+    const response = await fetch('/api/offences')
+    if (!response.ok) return []
+    window.OFFENCE_SEARCH_DATA = await response.json()
+    return window.OFFENCE_SEARCH_DATA
+  } catch {
+    return []
+  }
+}
+
+export const lookupOffenceDetails = (offenceId) => {
+  const offences = window.OFFENCE_SEARCH_DATA
+  if (!offences?.length || !offenceId) return null
+
+  const targetId = normaliseOffenceId(offenceId)
+
+  for (const group of offences) {
+    const match = (group.subOffences || []).find((sub) => normaliseOffenceId(sub.id) === targetId)
+    if (match) {
+      return {
+        id: match.id,
+        label: match.label || '',
+        code: match.code || '',
+        subcode: match.subcode || '',
+        fullCode: match.fullCode || '',
+        parentGroupDescription: group.category || '',
+        categoryDescription: group.label || '',
+        subCategoryDescription: match.description || match.label || '',
+        isViolentOffence: Boolean(match.isViolentOffence)
+      }
+    }
+  }
+
+  return null
+}
+
 export const lookupOffenceIsViolent = (offenceId) => {
   const offences = window.OFFENCE_SEARCH_DATA
   if (!offences?.length || !offenceId) return false
 
+  const targetId = normaliseOffenceId(offenceId)
+
   for (const group of offences) {
-    const match = (group.subOffences || []).find((sub) => sub.id === offenceId)
+    const match = (group.subOffences || []).find((sub) => normaliseOffenceId(sub.id) === targetId)
     if (match) return Boolean(match.isViolentOffence)
   }
 

--- a/app/assets/javascripts/dev/predictors-summary.js
+++ b/app/assets/javascripts/dev/predictors-summary.js
@@ -108,24 +108,6 @@ export const buildPredictorsSummarySections = (session, offenderFirstName = 'Ale
         false,
         PREDICTORS_CHANGE_ANCHORS.convictionDate,
         true
-      ),
-      createRow(
-        'Offence code',
-        offenceCodeLabel || null,
-        'a1.html',
-        'Offence code',
-        false,
-        TIERING_CHANGE_ANCHORS.currentOffence,
-        true
-      ),
-      createRow(
-        'Date of current conviction',
-        convictionDateLabel || null,
-        'a1.html',
-        'Date of current conviction',
-        false,
-        TIERING_CHANGE_ANCHORS.convictionDate,
-        true
       )
     ]
   })
@@ -170,7 +152,7 @@ export const buildPredictorsSummarySections = (session, offenderFirstName = 'Ale
 
   if (session.sexualOffence === 'yes') {
     sections.push({
-      title: 'Sexual or sexually motivated offending',
+      title: 'Current and recent sexual offending',
       rows: [
         createRow(
           `Does ${name}'s current offence have a sexual motivation?`,
@@ -244,33 +226,18 @@ export const buildPredictorsSummarySections = (session, offenderFirstName = 'Ale
     })
   }
 
-  const communitySupervisionRows = [
-    createRow(
-      `Is ${name} currently being supervised in the community?`,
-      formatChoice(session.supervisedInCommunity),
-      'a4.html',
-      `Is ${name} currently being supervised in the community?`,
-      false,
-      PREDICTORS_CHANGE_ANCHORS.supervisedInCommunity
-    )
-  ]
-
-  if (session.supervisedInCommunity === 'yes') {
-    communitySupervisionRows.push(
+  sections.push({
+    title: 'Community supervision',
+    rows: [
       createRow(
-        `What date did ${name}'s supervision begin?`,
+        `What date did ${name}'s current supervision in the community begin?`,
         formatDateFromParts(session.communityDate || {}),
         'a4.html',
-        `What date did ${name}'s supervision begin?`,
+        `What date did ${name}'s current supervision in the community begin?`,
         false,
         PREDICTORS_CHANGE_ANCHORS.supervisedCommunityDate
       )
-    )
-  }
-
-  sections.push({
-    title: 'Community supervision',
-    rows: communitySupervisionRows
+    ]
   })
 
   const communityDateLabel = formatDateFromParts(session.communityDate || {}) || 'that date'

--- a/app/assets/javascripts/tiering-a1-source-notice-toggle.js
+++ b/app/assets/javascripts/tiering-a1-source-notice-toggle.js
@@ -54,6 +54,10 @@ export const initA1SourceNoticeToggle = () => {
   const notice = document.querySelector('[data-a1-source-notice]')
   if (!button || !notice) return
 
+  // Return to OASys navigates a1 ↔ a1b when wired as a layout toggle
+  const href = button.getAttribute('href') || ''
+  if (href.includes('a1b')) return
+
   activateToggleButton(button)
   applyVariant(getStoredVariant())
 

--- a/app/assets/javascripts/tiering-b1-caption-progress-toggle.js
+++ b/app/assets/javascripts/tiering-b1-caption-progress-toggle.js
@@ -1,7 +1,7 @@
 //
 // b1 – cycle page layouts via Return to OASys
-// default: question as fieldset legend (H1-as-legend) with caption
-// section: caption Reoffending predictors + topic H1 + question in content
+// default: caption + question as H1 in the service header (a1 layout)
+// section: caption + topic H1 in header, question as H2 in content
 //
 
 const STORAGE_KEY = 'tiering-b1-caption-progress'
@@ -28,19 +28,19 @@ const getNextVariant = (current) => {
 
 const applyVariant = (variant) => {
   const isSection = variant === 'section'
-  const showLegendHeading = !isSection
 
   document.querySelectorAll('[data-b1-heading-variant]').forEach((el) => {
     const headingVariant = el.dataset.b1HeadingVariant
     el.toggleAttribute('hidden', isSection ? headingVariant !== 'section' : headingVariant !== 'default')
   })
 
+  // Always keep a1-style header spacing (never actions-only / legend-heading row)
   document.querySelectorAll('[data-b1-layout-heading]').forEach((el) => {
-    el.classList.toggle('assessment-service-header__question-row--legend-heading', showLegendHeading)
+    el.classList.remove('assessment-service-header__question-row--legend-heading')
   })
 
   document.querySelectorAll('[data-b1-layout-header]').forEach((el) => {
-    el.classList.toggle('assessment-service-header--legend-heading', showLegendHeading)
+    el.classList.remove('assessment-service-header--legend-heading')
   })
 
   document.querySelectorAll('[data-b1-header-hint]').forEach((el) => {
@@ -48,7 +48,7 @@ const applyVariant = (variant) => {
   })
 
   document.querySelectorAll('[data-b1-legend-hint]').forEach((el) => {
-    el.toggleAttribute('hidden', isSection)
+    el.toggleAttribute('hidden', true)
   })
 
   document.querySelectorAll('[data-b1-content-question]').forEach((el) => {
@@ -57,19 +57,13 @@ const applyVariant = (variant) => {
 
   const legend = document.querySelector('[data-b1-fieldset-legend]')
   if (legend) {
-    legend.classList.toggle('govuk-visually-hidden', !showLegendHeading)
-    legend.classList.toggle('govuk-fieldset__legend--l', showLegendHeading)
-    legend.classList.toggle('govuk-fieldset__legend--m', !showLegendHeading)
-    legend.classList.toggle('govuk-!-margin-bottom-2', showLegendHeading && Boolean(document.querySelector('[data-b1-legend-hint]')))
-    legend.classList.toggle('govuk-!-margin-bottom-4', showLegendHeading && !document.querySelector('[data-b1-legend-hint]'))
-    if (showLegendHeading && !legend.id) {
-      legend.id = 'predictors-accommodation-suitable'
-    } else if (!showLegendHeading) {
-      legend.removeAttribute('id')
-    }
+    legend.classList.add('govuk-visually-hidden')
+    legend.classList.remove('govuk-fieldset__legend--l', 'govuk-!-margin-bottom-2', 'govuk-!-margin-bottom-4')
+    legend.classList.add('govuk-fieldset__legend--m')
+    legend.removeAttribute('id')
 
-    legend.querySelectorAll('.govuk-caption-l, .govuk-visually-hidden').forEach((el) => {
-      el.toggleAttribute('hidden', !showLegendHeading)
+    legend.querySelectorAll('.govuk-caption-l').forEach((el) => {
+      el.setAttribute('hidden', '')
     })
   }
 

--- a/app/assets/javascripts/tiering-page-apis.js
+++ b/app/assets/javascripts/tiering-page-apis.js
@@ -1,5 +1,5 @@
 //
-// Path-aware Tiering APIs for shared scripts used by /01/, /02/, and /dev/
+// Path-aware APIs for shared scripts used by /01/, /02/, and /dev/
 //
 
 import * as session01 from './tiering-assessment-session.js'
@@ -23,21 +23,35 @@ const pick = (proto1, proto2, protoDev) => {
   return proto1
 }
 
-export const getA1FormElement = () =>
-  document.getElementById(isVersionedTieringPage() ? 'predictors-a1-form' : 'tiering-a1-form')
+export const getA1FormElement = () => {
+  if (!isVersionedTieringPage()) {
+    return document.getElementById('tiering-a1-form')
+  }
+
+  return (
+    document.getElementById('predictors-a1-form') ||
+    document.getElementById('predictors-a2b-form')
+  )
+}
 
 export const getConvictionDateHeadingElement = () =>
   document.getElementById(
     isVersionedTieringPage() ? 'predictors-conviction-date' : 'tiering-conviction-date'
   )
 
-export const getTieringChangeAnchors = () => pick(scroll01, scroll02, scrollDev).TIERING_CHANGE_ANCHORS
+export const getTieringChangeAnchors = () => {
+  const api = pick(scroll01, scroll02, scrollDev)
+  return api.PREDICTORS_CHANGE_ANCHORS || api.TIERING_CHANGE_ANCHORS
+}
+export const getTieringAssessmentSession = () => {
+  const api = pick(session01, session02, sessionDev)
+  return (api.getPredictorsAssessmentSession || api.getTieringAssessmentSession)()
+}
 
-export const getTieringAssessmentSession = () =>
-  pick(session01, session02, sessionDev).getTieringAssessmentSession()
-
-export const setTieringAssessmentSession = (updates) =>
-  pick(session01, session02, sessionDev).setTieringAssessmentSession(updates)
+export const setTieringAssessmentSession = (updates) => {
+  const api = pick(session01, session02, sessionDev)
+  return (api.setPredictorsAssessmentSession || api.setTieringAssessmentSession)(updates)
+}
 
 export const getDefaultConvictionDateParts = () =>
   pick(session01, session02, sessionDev).getDefaultConvictionDateParts()
@@ -57,8 +71,10 @@ export const getPrototypeDefaultCurrentOffence = () =>
 export const captureCheckAnswersEditSnapshot = (fields) =>
   pick(scroll01, scroll02, scrollDev).captureCheckAnswersEditSnapshot(fields)
 
-export const isTieringCheckAnswersEdit = () =>
-  pick(scroll01, scroll02, scrollDev).isTieringCheckAnswersEdit()
+export const isTieringCheckAnswersEdit = () => {
+  const api = pick(scroll01, scroll02, scrollDev)
+  return (api.isPredictorsCheckAnswersEdit || api.isTieringCheckAnswersEdit)()
+}
 
 export const TIERING_CHANGE_ANCHORS = scroll01.TIERING_CHANGE_ANCHORS
 

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -2811,6 +2811,35 @@ body.assessment-page {
   padding: 10px
 }
 
+// MOJ inset text (highlighted) – https://design-patterns.service.justice.gov.uk/components/inset-text-highlighted/
+.guidance-panel {
+  border-left-color: govuk-colour("blue");
+  background-color: #eaf4f9;
+}
+
+.a2b-current-offence {
+  cursor: pointer;
+
+  &:focus {
+    outline: 3px solid transparent;
+    box-shadow: 0 0 0 3px #fd0;
+  }
+
+  &:focus:not(:focus-visible) {
+    box-shadow: none;
+  }
+
+  &:focus-visible {
+    outline: 3px solid transparent;
+    box-shadow: 0 0 0 3px #fd0;
+  }
+
+  .a2b-current-offence__notice--plain {
+    margin-top: 0;
+    margin-bottom: govuk-spacing(4);
+  }
+}
+
 // Proto 2 / dev: predictors naming mirrors tiering component classes
 .predictors-question-anchor { @extend .tiering-question-anchor; }
 .predictors-offence-code { @extend .tiering-offence-code; }

--- a/app/routes.js
+++ b/app/routes.js
@@ -88,7 +88,7 @@ router.use((req, res, next) => {
     res.locals.useReoffendingServiceNavigation = true
     res.locals.hideOffenderViewAnswers = true
   }
-  if (/^\/(01|02)\/a2(\.html)?$/.test(req.path)) {
+  if (/^\/(01|02|dev)\/a2(b)?(\.html)?$/.test(req.path)) {
     Object.assign(res.locals, getFirstSanctionAgeLocals(req.query))
   }
   next()

--- a/app/views/02/a1.html
+++ b/app/views/02/a1.html
@@ -8,6 +8,7 @@
 {% set pageHeadingInset = "This information comes from NDelius. If any details are wrong, contact the case administrator at your probation delivery unit (PDU)." %}
 {% set pageHeadingSourceToggle = true %}
 {% set statusTag = "Incomplete" %}
+{% set returnToOasysButtonInclude = "includes/02/a1-layout-toggle-to-a1b.html" %}
 {% set backLinkHref = "#" %}
 {% set backLinkId = "predictors-a1-back" %}
 

--- a/app/views/02/a1b.html
+++ b/app/views/02/a1b.html
@@ -1,0 +1,22 @@
+{% extends "layouts/assessment-proto2.html" %}
+
+{% set offenderFirstName = "Alex" %}
+{% set pageName = "Reoffending predictor scores" %}
+{% set activeSection = "section-1" %}
+{% set pageHeading = "Reoffending predictor scores" %}
+{% set predictorsSectionCaption = false %}
+{% set returnToOasysButtonInclude = "includes/02/a1-layout-toggle-to-a1.html" %}
+{% set backLinkHref = "#" %}
+{% set backLinkId = "predictors-a1b-back" %}
+
+{% block content %}
+
+{% include "includes/assessment-journey-page-open.html" %}
+
+{% include "includes/assessment-question-header.html" %}
+
+{% include "includes/predictors-a1b-start-content.html" %}
+
+{% include "includes/assessment-page-close.html" %}
+
+{% endblock %}

--- a/app/views/02/a2.html
+++ b/app/views/02/a2.html
@@ -5,6 +5,7 @@
 {% set activeSection = "section-1" %}
 {% set pageHeading = "Offending history" %}
 {% set statusTag = "Incomplete" %}
+{% set returnToOasysButtonInclude = "includes/02/a2-layout-toggle-to-a2b.html" %}
 {% set backLinkHref = "a1.html" %}
 
 {% block content %}

--- a/app/views/02/a2b.html
+++ b/app/views/02/a2b.html
@@ -1,0 +1,50 @@
+{% extends "layouts/assessment-proto2.html" %}
+
+{% set offenderFirstName = "Alex" %}
+{% set pageName = "Current offence and offending history" %}
+{% set activeSection = "section-1" %}
+{% set pageHeading = "Current offence and offending history" %}
+{% set statusTag = "Incomplete" %}
+{% set returnToOasysButtonInclude = "includes/02/a2-layout-toggle-to-a2.html" %}
+{% set backLinkHref = "a1.html" %}
+
+{% block content %}
+
+{% include "includes/assessment-journey-page-open.html" %}
+
+<div id="predictors-a1-error-summary" class="govuk-error-summary" data-module="govuk-error-summary" tabindex="-1" hidden>
+  <div role="alert">
+    <h2 class="govuk-error-summary__title">There is a problem</h2>
+    <div class="govuk-error-summary__body"></div>
+  </div>
+</div>
+
+{% include "includes/assessment-question-header.html" %}
+
+<form id="predictors-a2b-form" novalidate data-offender-first-name="{{ offenderFirstName }}" data-a1-offence-display-default="table">
+
+  <div class="a2b-current-offence" data-a2b-current-offence data-a2b-current-offence-variant="default">
+    <h2 class="govuk-heading-m">Current offence</h2>
+
+    <div data-a2b-current-offence-panel>
+      <div class="govuk-inset-text" data-a2b-current-offence-notice>
+        This information comes from NDelius. If any details are wrong, contact the case administrator at your probation delivery unit (PDU).
+      </div>
+
+      {% include "includes/a1-current-offence-questions.html" %}
+    </div>
+  </div>
+
+  <h2 class="govuk-heading-m govuk-!-margin-top-9 govuk-!-padding-top-4">Offending history</h2>
+
+  {% include "includes/02/sanction-definition-inset.html" %}
+
+  {% include "includes/02/offending-history-questions.html" %}
+
+  <button type="submit" class="govuk-button govuk-!-margin-top-6" data-module="govuk-button">Save and continue</button>
+
+</form>
+
+{% include "includes/assessment-page-close.html" %}
+
+{% endblock %}

--- a/app/views/02/a3.html
+++ b/app/views/02/a3.html
@@ -4,6 +4,7 @@
 {% set pageName = "Sexual offending" %}
 {% set activeSection = "section-1" %}
 {% set pageHeading = "Sexual offending" %}
+{% set pageHeadingInset = "These questions calculate sexual reoffending predictors scores. Use the guidance provided to decide if an offence should be counted. Do not use your professional judgement to reclassify any offences." %}
 {% set statusTag = "Incomplete" %}
 {% set backLinkHref = "a2.html" %}
 

--- a/app/views/02/a4.html
+++ b/app/views/02/a4.html
@@ -2,9 +2,11 @@
 
 {% set offenderFirstName = "Alex" %}
 {% set pageName = "Community supervision" %}
-{% set pageHeadingHtml = 'Is ' ~ offenderFirstName ~ ' currently being supervised in the community?' %}
-{% set pageHeadingId = "predictors-supervised-in-community" %}
+{% set pageHeadingHtml = "What date did " ~ offenderFirstName ~ "'s current supervision in the community begin?" %}
+{% set pageHeadingId = "predictors-supervised-community-date" %}
 {% set pageHeadingClass = "predictors-question-anchor" %}
+{% set pageHeadingHint = "We will fill in this date from previous assessment data if it is available. Change the date if it is wrong." %}
+{% set pageHeadingHintId = "supervised-community-date-hint" %}
 {% set compactPageHeader = true %}
 {% set activeSection = "section-1" %}
 {% set statusTag = "Incomplete" %}
@@ -19,7 +21,7 @@
 
 <form id="predictors-a4-form" novalidate>
 
-  {% include "includes/community-date-question.html" %}
+  {% include "includes/predictors-community-date-question.html" %}
 
   <button type="submit" class="govuk-button govuk-!-margin-top-6" data-module="govuk-button">Save and continue</button>
 

--- a/app/views/02/b1.html
+++ b/app/views/02/b1.html
@@ -54,6 +54,10 @@
           <input class="govuk-radios__input" id="accommodation-suitable-no" name="accommodation_suitable" type="radio" value="no">
           <label class="govuk-label govuk-radios__label" for="accommodation-suitable-no">No</label>
         </div>
+        <div class="govuk-radios__item">
+          <input class="govuk-radios__input" id="accommodation-suitable-unknown" name="accommodation_suitable" type="radio" value="unknown">
+          <label class="govuk-label govuk-radios__label" for="accommodation-suitable-unknown">Unknown</label>
+        </div>
       </div>
     </fieldset>
   </div>

--- a/app/views/02/b3.html
+++ b/app/views/02/b3.html
@@ -38,6 +38,10 @@
           <input class="govuk-radios__input" id="drugs-misused-no" name="drugs_misused" type="radio" value="no">
           <label class="govuk-label govuk-radios__label" for="drugs-misused-no">No</label>
         </div>
+        <div class="govuk-radios__item">
+          <input class="govuk-radios__input" id="drugs-misused-unknown" name="drugs_misused" type="radio" value="unknown">
+          <label class="govuk-label govuk-radios__label" for="drugs-misused-unknown">Unknown</label>
+        </div>
       </div>
     </fieldset>
   </div>

--- a/app/views/02/b5.html
+++ b/app/views/02/b5.html
@@ -40,6 +40,10 @@
           <input class="govuk-radios__input" id="alcohol-use-no" name="alcohol_use" type="radio" value="no">
           <label class="govuk-label govuk-radios__label" for="alcohol-use-no">No</label>
         </div>
+        <div class="govuk-radios__item">
+          <input class="govuk-radios__input" id="alcohol-use-unknown" name="alcohol_use" type="radio" value="unknown">
+          <label class="govuk-label govuk-radios__label" for="alcohol-use-unknown">Unknown</label>
+        </div>
       </div>
     </fieldset>
   </div>

--- a/app/views/02/b7.html
+++ b/app/views/02/b7.html
@@ -40,6 +40,10 @@
           <input class="govuk-radios__input" id="relationship-status-unhappy-unhealthy" name="relationship_status" type="radio" value="unhappy-unhealthy">
           <label class="govuk-label govuk-radios__label" for="relationship-status-unhappy-unhealthy">Unhappy about their relationship status, or their relationship is unhealthy and directly linked to offending</label>
         </div>
+        <div class="govuk-radios__item">
+          <input class="govuk-radios__input" id="relationship-status-unknown" name="relationship_status" type="radio" value="unknown">
+          <label class="govuk-label govuk-radios__label" for="relationship-status-unknown">Unknown</label>
+        </div>
       </div>
     </fieldset>
   </div>

--- a/app/views/dev/a1.html
+++ b/app/views/dev/a1.html
@@ -8,6 +8,7 @@
 {% set pageHeadingInset = "This information comes from NDelius. If any details are wrong, contact the case administrator at your probation delivery unit (PDU)." %}
 {% set pageHeadingSourceToggle = true %}
 {% set statusTag = "Incomplete" %}
+{% set returnToOasysButtonInclude = "includes/dev/a1-layout-toggle-to-a1b.html" %}
 {% set backLinkHref = "#" %}
 {% set backLinkId = "predictors-a1-back" %}
 

--- a/app/views/dev/a1b.html
+++ b/app/views/dev/a1b.html
@@ -1,0 +1,22 @@
+{% extends "layouts/assessment-proto-dev.html" %}
+
+{% set offenderFirstName = "Alex" %}
+{% set pageName = "Reoffending predictor scores" %}
+{% set activeSection = "section-1" %}
+{% set pageHeading = "Reoffending predictor scores" %}
+{% set predictorsSectionCaption = false %}
+{% set returnToOasysButtonInclude = "includes/dev/a1-layout-toggle-to-a1.html" %}
+{% set backLinkHref = "#" %}
+{% set backLinkId = "predictors-a1b-back" %}
+
+{% block content %}
+
+{% include "includes/assessment-journey-page-open.html" %}
+
+{% include "includes/assessment-question-header.html" %}
+
+{% include "includes/predictors-a1b-start-content.html" %}
+
+{% include "includes/assessment-page-close.html" %}
+
+{% endblock %}

--- a/app/views/dev/a2.html
+++ b/app/views/dev/a2.html
@@ -5,6 +5,7 @@
 {% set activeSection = "section-1" %}
 {% set pageHeading = "Offending history" %}
 {% set statusTag = "Incomplete" %}
+{% set returnToOasysButtonInclude = "includes/dev/a2-layout-toggle-to-a2b.html" %}
 {% set backLinkHref = "a1.html" %}
 
 {% block content %}

--- a/app/views/dev/a2b.html
+++ b/app/views/dev/a2b.html
@@ -1,0 +1,50 @@
+{% extends "layouts/assessment-proto-dev.html" %}
+
+{% set offenderFirstName = "Alex" %}
+{% set pageName = "Current offence and offending history" %}
+{% set activeSection = "section-1" %}
+{% set pageHeading = "Current offence and offending history" %}
+{% set statusTag = "Incomplete" %}
+{% set returnToOasysButtonInclude = "includes/dev/a2-layout-toggle-to-a2.html" %}
+{% set backLinkHref = "a1.html" %}
+
+{% block content %}
+
+{% include "includes/assessment-journey-page-open.html" %}
+
+<div id="predictors-a1-error-summary" class="govuk-error-summary" data-module="govuk-error-summary" tabindex="-1" hidden>
+  <div role="alert">
+    <h2 class="govuk-error-summary__title">There is a problem</h2>
+    <div class="govuk-error-summary__body"></div>
+  </div>
+</div>
+
+{% include "includes/assessment-question-header.html" %}
+
+<form id="predictors-a2b-form" novalidate data-offender-first-name="{{ offenderFirstName }}" data-a1-offence-display-default="table">
+
+  <div class="a2b-current-offence" data-a2b-current-offence data-a2b-current-offence-variant="default">
+    <h2 class="govuk-heading-m">Current offence</h2>
+
+    <div data-a2b-current-offence-panel>
+      <div class="govuk-inset-text" data-a2b-current-offence-notice>
+        This information comes from NDelius. If any details are wrong, contact the case administrator at your probation delivery unit (PDU).
+      </div>
+
+      {% include "includes/a1-current-offence-questions.html" %}
+    </div>
+  </div>
+
+  <h2 class="govuk-heading-m govuk-!-margin-top-9 govuk-!-padding-top-4">Offending history</h2>
+
+  {% include "includes/dev/sanction-definition-inset.html" %}
+
+  {% include "includes/dev/offending-history-questions.html" %}
+
+  <button type="submit" class="govuk-button govuk-!-margin-top-6" data-module="govuk-button">Save and continue</button>
+
+</form>
+
+{% include "includes/assessment-page-close.html" %}
+
+{% endblock %}

--- a/app/views/dev/a3.html
+++ b/app/views/dev/a3.html
@@ -4,6 +4,7 @@
 {% set pageName = "Sexual offending" %}
 {% set activeSection = "section-1" %}
 {% set pageHeading = "Sexual offending" %}
+{% set pageHeadingInset = "These questions calculate sexual reoffending predictors scores. Use the guidance provided to decide if an offence should be counted. Do not use your professional judgement to reclassify any offences." %}
 {% set statusTag = "Incomplete" %}
 {% set backLinkHref = "a2.html" %}
 

--- a/app/views/dev/a4.html
+++ b/app/views/dev/a4.html
@@ -2,9 +2,11 @@
 
 {% set offenderFirstName = "Alex" %}
 {% set pageName = "Community supervision" %}
-{% set pageHeadingHtml = 'Is ' ~ offenderFirstName ~ ' currently being supervised in the community?' %}
-{% set pageHeadingId = "predictors-supervised-in-community" %}
+{% set pageHeadingHtml = "What date did " ~ offenderFirstName ~ "'s current supervision in the community begin?" %}
+{% set pageHeadingId = "predictors-supervised-community-date" %}
 {% set pageHeadingClass = "predictors-question-anchor" %}
+{% set pageHeadingHint = "We will fill in this date from previous assessment data if it is available. Change the date if it is wrong." %}
+{% set pageHeadingHintId = "supervised-community-date-hint" %}
 {% set compactPageHeader = true %}
 {% set activeSection = "section-1" %}
 {% set statusTag = "Incomplete" %}
@@ -19,7 +21,7 @@
 
 <form id="predictors-a4-form" novalidate>
 
-  {% include "includes/community-date-question.html" %}
+  {% include "includes/predictors-community-date-question.html" %}
 
   <button type="submit" class="govuk-button govuk-!-margin-top-6" data-module="govuk-button">Save and continue</button>
 

--- a/app/views/includes/02/a1-layout-toggle-to-a1.html
+++ b/app/views/includes/02/a1-layout-toggle-to-a1.html
@@ -1,0 +1,1 @@
+<a href="a1.html" class="govuk-button govuk-button--secondary assessment-layout__return-to-oasys" data-module="govuk-button">Return to OASys</a>

--- a/app/views/includes/02/a1-layout-toggle-to-a1b.html
+++ b/app/views/includes/02/a1-layout-toggle-to-a1b.html
@@ -1,0 +1,1 @@
+<a href="a1b.html" class="govuk-button govuk-button--secondary assessment-layout__return-to-oasys" data-module="govuk-button">Return to OASys</a>

--- a/app/views/includes/02/a2-layout-toggle-to-a2.html
+++ b/app/views/includes/02/a2-layout-toggle-to-a2.html
@@ -1,0 +1,1 @@
+<a href="a2.html" class="govuk-button govuk-button--secondary assessment-layout__return-to-oasys" data-module="govuk-button">Return to OASys</a>

--- a/app/views/includes/02/a2-layout-toggle-to-a2b.html
+++ b/app/views/includes/02/a2-layout-toggle-to-a2b.html
@@ -1,0 +1,1 @@
+<a href="a2b.html" class="govuk-button govuk-button--secondary assessment-layout__return-to-oasys" data-module="govuk-button">Return to OASys</a>

--- a/app/views/includes/02/assessment-service-header-journey.html
+++ b/app/views/includes/02/assessment-service-header-journey.html
@@ -1,13 +1,13 @@
 {# Set pageHeading per page; optional predictorsSectionCaption (default Reoffending predictors) and statusTag #}
-<div class="govuk-grid-row assessment-service-header{% if hidePageHeaderSeparator %} assessment-service-header--no-separator{% endif %}{% if pageHeadingHtml and questionLegendAsHeading %} assessment-service-header--legend-heading{% endif %}">
+<div class="govuk-grid-row assessment-service-header{% if hidePageHeaderSeparator %} assessment-service-header--no-separator{% endif %}">
   <div class="govuk-grid-column-full">
-    <div class="assessment-layout__row assessment-layout__row--tight assessment-service-header__question-row{% if pageHeadingHtml and questionLegendAsHeading %} assessment-service-header__question-row--legend-heading{% endif %}">
-      {% if not (pageHeadingHtml and questionLegendAsHeading) %}
+    <div class="assessment-layout__row assessment-layout__row--tight assessment-service-header__question-row">
       <h1 class="govuk-heading-l govuk-!-margin-bottom-0{% if pageHeadingClass %} {{ pageHeadingClass }}{% endif %}"{% if pageHeadingId %} id="{{ pageHeadingId }}"{% endif %}>
+        {% if predictorsSectionCaption !== false %}
         <span class="govuk-caption-l assessment-service-header__section-caption">{{ predictorsSectionCaption | default("Reoffending predictors") }}</span>
+        {% endif %}
         {% if pageHeadingHtml %}{{ pageHeadingHtml | safe }}{% else %}{{ pageHeading | default("Reoffending predictors assessment") }}{% endif %}{% if statusTag %}<span class="govuk-visually-hidden">, {{ statusTag }}</span>{% endif %}
       </h1>
-      {% endif %}
       <div class="assessment-service-header__actions">
         {% if statusTag %}
         <strong class="govuk-tag govuk-tag--grey assessment-layout__status-tag" aria-hidden="true">{{ statusTag }}</strong>
@@ -25,11 +25,15 @@
     {% elif pageHeadingInset %}
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <div class="govuk-inset-text assessment-service-header__heading-inset govuk-!-margin-bottom-0">{{ pageHeadingInset }}</div>
+        <div class="govuk-inset-text assessment-service-header__heading-inset">{{ pageHeadingInset }}</div>
       </div>
     </div>
-    {% elif pageHeadingHint and not (pageHeadingHtml and questionLegendAsHeading) %}
-    <p{% if pageHeadingHintId %} id="{{ pageHeadingHintId }}"{% endif %} class="govuk-hint assessment-service-header__heading-hint govuk-!-margin-bottom-0">{{ pageHeadingHint }}</p>
+    {% elif pageHeadingHint %}
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <p{% if pageHeadingHintId %} id="{{ pageHeadingHintId }}"{% endif %} class="govuk-hint assessment-service-header__heading-hint govuk-!-margin-bottom-0">{{ pageHeadingHint }}</p>
+      </div>
+    </div>
     {% endif %}
     {% if not hidePageHeaderSeparator %}
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">

--- a/app/views/includes/02/b1-assessment-service-header-journey.html
+++ b/app/views/includes/02/b1-assessment-service-header-journey.html
@@ -1,13 +1,11 @@
 {# b1-only layout variants toggled by Return to OASys #}
-<div class="govuk-grid-row assessment-service-header{% if hidePageHeaderSeparator %} assessment-service-header--no-separator{% endif %}{% if pageHeadingHtml and questionLegendAsHeading %} assessment-service-header--legend-heading{% endif %}" data-b1-layout-header>
+<div class="govuk-grid-row assessment-service-header{% if hidePageHeaderSeparator %} assessment-service-header--no-separator{% endif %}" data-b1-layout-header>
   <div class="govuk-grid-column-full">
-    <div class="assessment-layout__row assessment-layout__row--tight assessment-service-header__question-row{% if pageHeadingHtml and questionLegendAsHeading %} assessment-service-header__question-row--legend-heading{% endif %}" data-b1-layout-heading>
-      {% if not (pageHeadingHtml and questionLegendAsHeading) %}
+    <div class="assessment-layout__row assessment-layout__row--tight assessment-service-header__question-row" data-b1-layout-heading>
       <h1 class="govuk-heading-l govuk-!-margin-bottom-0{% if pageHeadingClass %} {{ pageHeadingClass }}{% endif %}" data-b1-heading-variant="default"{% if pageHeadingId %} id="{{ pageHeadingId }}"{% endif %}>
         <span class="govuk-caption-l assessment-service-header__section-caption">{{ predictorsSectionCaption | default("Reoffending predictors") }}</span>
         {% if pageHeadingHtml %}{{ pageHeadingHtml | safe }}{% endif %}{% if statusTag %}<span class="govuk-visually-hidden">, {{ statusTag }}</span>{% endif %}
       </h1>
-      {% endif %}
       <h1 class="govuk-heading-l govuk-!-margin-bottom-0" data-b1-heading-variant="section" hidden>
         <span class="govuk-caption-l assessment-service-header__section-caption">{{ predictorsSectionCaptionSection | default("Reoffending predictors") }}</span>
         {{ pageHeadingSection | default("Accommodation") }}{% if statusTag %}<span class="govuk-visually-hidden">, {{ statusTag }}</span>{% endif %}
@@ -19,8 +17,12 @@
         {% include returnToOasysButtonInclude | default("includes/02/return-to-oasys-button.html") %}
       </div>
     </div>
-    {% if pageHeadingHint and not (pageHeadingHtml and questionLegendAsHeading) %}
-    <p{% if pageHeadingHintId %} id="{{ pageHeadingHintId }}"{% endif %} class="govuk-hint assessment-service-header__heading-hint govuk-!-margin-bottom-0" data-b1-header-hint>{{ pageHeadingHint }}</p>
+    {% if pageHeadingHint %}
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <p{% if pageHeadingHintId %} id="{{ pageHeadingHintId }}"{% endif %} class="govuk-hint assessment-service-header__heading-hint govuk-!-margin-bottom-0" data-b1-header-hint>{{ pageHeadingHint }}</p>
+      </div>
+    </div>
     {% endif %}
     {% if not hidePageHeaderSeparator %}
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">

--- a/app/views/includes/02/direct-contact-questions.html
+++ b/app/views/includes/02/direct-contact-questions.html
@@ -53,7 +53,7 @@
   </div>
 </details>
 
-<div class="govuk-form-group govuk-!-margin-bottom-0">
+<div class="govuk-form-group govuk-!-margin-bottom-8">
   <label class="govuk-label govuk-visually-hidden" for="contact-child-sanctions">
     How many sanctions does {{ offenderFirstName }} have for direct contact child sexual or sexually motivated offences?
   </label>
@@ -66,4 +66,39 @@
     autocomplete="off"
     aria-describedby="contact-child-sanctions-hint"
   >
+</div>
+
+<h3 id="predictors-stranger-contact" class="govuk-heading-s predictors-question-anchor govuk-!-margin-top-0 govuk-!-margin-bottom-2">
+  Does {{ offenderFirstName }}'s current offence involve actual or attempted direct contact against a victim who was a stranger?
+</h3>
+
+<details class="govuk-details govuk-!-margin-bottom-4">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">When to answer yes to this question</span>
+  </summary>
+  <div class="govuk-details__text">
+    {% include "includes/02/stranger-contact-yes-guidance.html" %}
+  </div>
+</details>
+
+<div class="govuk-form-group govuk-!-margin-bottom-0">
+  <fieldset class="govuk-fieldset">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--m govuk-visually-hidden">
+      Does {{ offenderFirstName }}'s current offence involve actual or attempted direct contact against a victim who was a stranger?
+    </legend>
+    <div class="govuk-radios govuk-radios--inline" data-module="govuk-radios">
+      <div class="govuk-radios__item">
+        <input class="govuk-radios__input" id="stranger-contact-yes" name="stranger_contact" type="radio" value="yes">
+        <label class="govuk-label govuk-radios__label" for="stranger-contact-yes">Yes</label>
+      </div>
+      <div class="govuk-radios__item">
+        <input class="govuk-radios__input" id="stranger-contact-no" name="stranger_contact" type="radio" value="no">
+        <label class="govuk-label govuk-radios__label" for="stranger-contact-no">No</label>
+      </div>
+      <div class="govuk-radios__item" hidden aria-hidden="true" style="display: none;">
+        <input class="govuk-radios__input" id="stranger-contact-unknown" name="stranger_contact" type="radio" value="unknown" disabled>
+        <label class="govuk-label govuk-radios__label" for="stranger-contact-unknown">Unknown</label>
+      </div>
+    </div>
+  </fieldset>
 </div>

--- a/app/views/includes/02/indirect-contact-non-contact-offences-counted.html
+++ b/app/views/includes/02/indirect-contact-non-contact-offences-counted.html
@@ -13,8 +13,15 @@
   <li>sexual penetration of a corpse</li>
 </ul>
 
+<p class="govuk-body govuk-!-margin-bottom-2">If an offence is not listed above, it should still be counted if:</p>
+<ul class="govuk-list govuk-list--bullet">
+  <li>you have explicit evidence that it has a sexual motivation</li>
+  <li>there is no actual contact or intent to have contact with a live human being</li>
+</ul>
+
 <p class="govuk-body govuk-!-margin-bottom-2">Do not count:</p>
 <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-0">
   <li>offences related to paying for or being paid for sex</li>
   <li>breach offences</li>
+  <li>convictions under the Criminal Justice and Courts Act 2015</li>
 </ul>

--- a/app/views/includes/02/offence-analysis-questions.html
+++ b/app/views/includes/02/offence-analysis-questions.html
@@ -84,6 +84,10 @@
         <input class="govuk-radios__input" id="domestic-abuse-perpetrator-no" name="domestic_abuse_perpetrator" type="radio" value="no">
         <label class="govuk-label govuk-radios__label" for="domestic-abuse-perpetrator-no">No</label>
       </div>
+      <div class="govuk-radios__item">
+        <input class="govuk-radios__input" id="domestic-abuse-perpetrator-unknown" name="domestic_abuse_perpetrator" type="radio" value="unknown">
+        <label class="govuk-label govuk-radios__label" for="domestic-abuse-perpetrator-unknown">Unknown</label>
+      </div>
     </div>
   </fieldset>
 </div>
@@ -133,6 +137,10 @@
       <div class="govuk-radios__item">
         <input class="govuk-radios__input" id="domestic-abuse-victim-no" name="domestic_abuse_victim" type="radio" value="no">
         <label class="govuk-label govuk-radios__label" for="domestic-abuse-victim-no">No</label>
+      </div>
+      <div class="govuk-radios__item">
+        <input class="govuk-radios__input" id="domestic-abuse-victim-unknown" name="domestic_abuse_victim" type="radio" value="unknown">
+        <label class="govuk-label govuk-radios__label" for="domestic-abuse-victim-unknown">Unknown</label>
       </div>
     </div>
   </fieldset>

--- a/app/views/includes/02/offending-history-questions.html
+++ b/app/views/includes/02/offending-history-questions.html
@@ -4,8 +4,12 @@
   What was the date of {{ offenderFirstName }}'s first sanction?
 </h2>
 
+<div id="first-sanction-date-hint" class="govuk-hint govuk-!-margin-bottom-4">
+  We will fill in this date from previous assessment data if it is available. Change the date if it is wrong.
+</div>
+
 <div class="govuk-form-group" data-first-sanction-date-field>
-  <fieldset class="govuk-fieldset" role="group" aria-describedby="first-sanction-age-result">
+  <fieldset class="govuk-fieldset" role="group" aria-describedby="first-sanction-date-hint first-sanction-age-result">
     <legend class="govuk-fieldset__legend govuk-fieldset__legend--m govuk-visually-hidden">
       What was the date of {{ offenderFirstName }}'s first sanction?
     </legend>

--- a/app/views/includes/02/sexual-offending-questions.html
+++ b/app/views/includes/02/sexual-offending-questions.html
@@ -1,6 +1,6 @@
 {# Requires offenderFirstName, e.g. {% set offenderFirstName = "Alex" %} #}
 
-<h2 class="govuk-heading-m govuk-!-margin-top-0 govuk-!-margin-bottom-6">Sexual or sexually motivated offending</h2>
+<h2 class="govuk-heading-m govuk-!-margin-top-0 govuk-!-margin-bottom-6">Current and recent sexual offending</h2>
 
 {% include "includes/02/sexual-offending-section-questions.html" %}
 

--- a/app/views/includes/02/sexual-offending-section-questions.html
+++ b/app/views/includes/02/sexual-offending-section-questions.html
@@ -26,41 +26,6 @@
   </fieldset>
 </div>
 
-<h3 id="predictors-stranger-contact" class="govuk-heading-s predictors-question-anchor govuk-!-margin-top-0 govuk-!-margin-bottom-2">
-  Does {{ offenderFirstName }}'s current offence involve actual or attempted direct contact against a victim who was a stranger?
-</h3>
-
-<details class="govuk-details govuk-!-margin-bottom-4">
-  <summary class="govuk-details__summary">
-    <span class="govuk-details__summary-text">When to answer yes to this question</span>
-  </summary>
-  <div class="govuk-details__text">
-    {% include "includes/02/stranger-contact-yes-guidance.html" %}
-  </div>
-</details>
-
-<div class="govuk-form-group govuk-!-margin-bottom-8">
-  <fieldset class="govuk-fieldset">
-    <legend class="govuk-fieldset__legend govuk-fieldset__legend--m govuk-visually-hidden">
-      Does {{ offenderFirstName }}'s current offence involve actual or attempted direct contact against a victim who was a stranger?
-    </legend>
-    <div class="govuk-radios govuk-radios--inline" data-module="govuk-radios">
-      <div class="govuk-radios__item">
-        <input class="govuk-radios__input" id="stranger-contact-yes" name="stranger_contact" type="radio" value="yes">
-        <label class="govuk-label govuk-radios__label" for="stranger-contact-yes">Yes</label>
-      </div>
-      <div class="govuk-radios__item">
-        <input class="govuk-radios__input" id="stranger-contact-no" name="stranger_contact" type="radio" value="no">
-        <label class="govuk-label govuk-radios__label" for="stranger-contact-no">No</label>
-      </div>
-      <div class="govuk-radios__item" hidden aria-hidden="true" style="display: none;">
-        <input class="govuk-radios__input" id="stranger-contact-unknown" name="stranger_contact" type="radio" value="unknown" disabled>
-        <label class="govuk-label govuk-radios__label" for="stranger-contact-unknown">Unknown</label>
-      </div>
-    </div>
-  </fieldset>
-</div>
-
 <h3 id="predictors-sexual-sanction-date" class="govuk-heading-s predictors-question-anchor govuk-!-margin-top-0 govuk-!-margin-bottom-2">
   What is the date of {{ offenderFirstName }}'s most recent sanction involving a sexual or sexually motivated offence?
 </h3>

--- a/app/views/includes/02/thinking-attitudes-behaviours-questions.html
+++ b/app/views/includes/02/thinking-attitudes-behaviours-questions.html
@@ -21,6 +21,10 @@
         <input class="govuk-radios__input" id="activities-linked-regularly" name="activities_linked_to_offending" type="radio" value="regularly-encourages-unaware">
         <label class="govuk-label govuk-radios__label" for="activities-linked-regularly">Regularly engages in activities which encourage offending and is not aware or does not care about the link to offending</label>
       </div>
+      <div class="govuk-radios__item">
+        <input class="govuk-radios__input" id="activities-linked-unknown" name="activities_linked_to_offending" type="radio" value="unknown">
+        <label class="govuk-label govuk-radios__label" for="activities-linked-unknown">Unknown</label>
+      </div>
     </div>
   </fieldset>
 </div>
@@ -50,6 +54,10 @@
           This may result in a loss of control or inability to stay calm until they have expressed their anger.
         </div>
       </div>
+      <div class="govuk-radios__item">
+        <input class="govuk-radios__input" id="manage-temper-unknown" name="manage_temper" type="radio" value="unknown">
+        <label class="govuk-label govuk-radios__label" for="manage-temper-unknown">Unknown</label>
+      </div>
     </div>
   </fieldset>
 </div>
@@ -76,6 +84,10 @@
         <input class="govuk-radios__input" id="act-on-impulse-significant" name="act_on_impulse" type="radio" value="significant-problems">
         <label class="govuk-label govuk-radios__label" for="act-on-impulse-significant">Acts on impulse which causes significant problems</label>
       </div>
+      <div class="govuk-radios__item">
+        <input class="govuk-radios__input" id="act-on-impulse-unknown" name="act_on_impulse" type="radio" value="unknown">
+        <label class="govuk-label govuk-radios__label" for="act-on-impulse-unknown">Unknown</label>
+      </div>
     </div>
   </fieldset>
 </div>
@@ -101,6 +113,10 @@
       <div class="govuk-radios__item">
         <input class="govuk-radios__input" id="support-criminal-behaviour-yes" name="support_criminal_behaviour" type="radio" value="supports-or-excuses-issue">
         <label class="govuk-label govuk-radios__label" for="support-criminal-behaviour-yes">Supports or excuses criminal behaviour or their pattern of behaviour and other evidence indicates this is an issue</label>
+      </div>
+      <div class="govuk-radios__item">
+        <input class="govuk-radios__input" id="support-criminal-behaviour-unknown" name="support_criminal_behaviour" type="radio" value="unknown">
+        <label class="govuk-label govuk-radios__label" for="support-criminal-behaviour-unknown">Unknown</label>
       </div>
     </div>
   </fieldset>

--- a/app/views/includes/assessment-journey-page-title.html
+++ b/app/views/includes/assessment-journey-page-title.html
@@ -1,4 +1,8 @@
-{%- set journeyPageTitleCaption = predictorsSectionCaption | default(tieringSectionCaption) | default("Reoffending predictors") -%}
+{%- if predictorsSectionCaption !== false -%}
+  {%- set journeyPageTitleCaption = predictorsSectionCaption | default(tieringSectionCaption) | default("Reoffending predictors") -%}
+{%- else -%}
+  {%- set journeyPageTitleCaption = "" -%}
+{%- endif -%}
 {%- if pageHeadingHtml -%}
   {%- set journeyPageTitleHeading = pageHeadingHtml | striptags -%}
 {%- elif pageHeading -%}
@@ -14,4 +18,8 @@
   {%- set journeyPageTitleHeading = "Tiering assessment" -%}
   {%- endif -%}
 {%- endif -%}
+{%- if journeyPageTitleCaption -%}
 {{- journeyPageTitleCaption }} - {{ journeyPageTitleHeading -}}
+{%- else -%}
+{{- journeyPageTitleHeading -}}
+{%- endif -%}

--- a/app/views/includes/dev/a1-layout-toggle-to-a1.html
+++ b/app/views/includes/dev/a1-layout-toggle-to-a1.html
@@ -1,0 +1,1 @@
+<a href="a1.html" class="govuk-button govuk-button--secondary assessment-layout__return-to-oasys" data-module="govuk-button">Return to OASys</a>

--- a/app/views/includes/dev/a1-layout-toggle-to-a1b.html
+++ b/app/views/includes/dev/a1-layout-toggle-to-a1b.html
@@ -1,0 +1,1 @@
+<a href="a1b.html" class="govuk-button govuk-button--secondary assessment-layout__return-to-oasys" data-module="govuk-button">Return to OASys</a>

--- a/app/views/includes/dev/a2-layout-toggle-to-a2.html
+++ b/app/views/includes/dev/a2-layout-toggle-to-a2.html
@@ -1,0 +1,1 @@
+<a href="a2.html" class="govuk-button govuk-button--secondary assessment-layout__return-to-oasys" data-module="govuk-button">Return to OASys</a>

--- a/app/views/includes/dev/a2-layout-toggle-to-a2b.html
+++ b/app/views/includes/dev/a2-layout-toggle-to-a2b.html
@@ -1,0 +1,1 @@
+<a href="a2b.html" class="govuk-button govuk-button--secondary assessment-layout__return-to-oasys" data-module="govuk-button">Return to OASys</a>

--- a/app/views/includes/dev/assessment-service-header-journey.html
+++ b/app/views/includes/dev/assessment-service-header-journey.html
@@ -1,13 +1,13 @@
 {# Set pageHeading per page; optional predictorsSectionCaption (default Reoffending predictors) and statusTag #}
-<div class="govuk-grid-row assessment-service-header{% if hidePageHeaderSeparator %} assessment-service-header--no-separator{% endif %}{% if pageHeadingHtml and questionLegendAsHeading %} assessment-service-header--legend-heading{% endif %}">
+<div class="govuk-grid-row assessment-service-header{% if hidePageHeaderSeparator %} assessment-service-header--no-separator{% endif %}">
   <div class="govuk-grid-column-full">
-    <div class="assessment-layout__row assessment-layout__row--tight assessment-service-header__question-row{% if pageHeadingHtml and questionLegendAsHeading %} assessment-service-header__question-row--legend-heading{% endif %}">
-      {% if not (pageHeadingHtml and questionLegendAsHeading) %}
+    <div class="assessment-layout__row assessment-layout__row--tight assessment-service-header__question-row">
       <h1 class="govuk-heading-l govuk-!-margin-bottom-0{% if pageHeadingClass %} {{ pageHeadingClass }}{% endif %}"{% if pageHeadingId %} id="{{ pageHeadingId }}"{% endif %}>
+        {% if predictorsSectionCaption !== false %}
         <span class="govuk-caption-l assessment-service-header__section-caption">{{ predictorsSectionCaption | default("Reoffending predictors") }}</span>
+        {% endif %}
         {% if pageHeadingHtml %}{{ pageHeadingHtml | safe }}{% else %}{{ pageHeading | default("Reoffending predictors assessment") }}{% endif %}{% if statusTag %}<span class="govuk-visually-hidden">, {{ statusTag }}</span>{% endif %}
       </h1>
-      {% endif %}
       <div class="assessment-service-header__actions">
         {% if statusTag %}
         <strong class="govuk-tag govuk-tag--grey assessment-layout__status-tag" aria-hidden="true">{{ statusTag }}</strong>
@@ -25,11 +25,15 @@
     {% elif pageHeadingInset %}
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <div class="govuk-inset-text assessment-service-header__heading-inset govuk-!-margin-bottom-0">{{ pageHeadingInset }}</div>
+        <div class="govuk-inset-text assessment-service-header__heading-inset">{{ pageHeadingInset }}</div>
       </div>
     </div>
-    {% elif pageHeadingHint and not (pageHeadingHtml and questionLegendAsHeading) %}
-    <p{% if pageHeadingHintId %} id="{{ pageHeadingHintId }}"{% endif %} class="govuk-hint assessment-service-header__heading-hint govuk-!-margin-bottom-0">{{ pageHeadingHint }}</p>
+    {% elif pageHeadingHint %}
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <p{% if pageHeadingHintId %} id="{{ pageHeadingHintId }}"{% endif %} class="govuk-hint assessment-service-header__heading-hint govuk-!-margin-bottom-0">{{ pageHeadingHint }}</p>
+      </div>
+    </div>
     {% endif %}
     {% if not hidePageHeaderSeparator %}
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">

--- a/app/views/includes/dev/direct-contact-questions.html
+++ b/app/views/includes/dev/direct-contact-questions.html
@@ -53,7 +53,7 @@
   </div>
 </details>
 
-<div class="govuk-form-group govuk-!-margin-bottom-0">
+<div class="govuk-form-group govuk-!-margin-bottom-8">
   <label class="govuk-label govuk-visually-hidden" for="contact-child-sanctions">
     How many sanctions does {{ offenderFirstName }} have for direct contact child sexual or sexually motivated offences?
   </label>
@@ -66,4 +66,39 @@
     autocomplete="off"
     aria-describedby="contact-child-sanctions-hint"
   >
+</div>
+
+<h3 id="predictors-stranger-contact" class="govuk-heading-s predictors-question-anchor govuk-!-margin-top-0 govuk-!-margin-bottom-2">
+  Does {{ offenderFirstName }}'s current offence involve actual or attempted direct contact against a victim who was a stranger?
+</h3>
+
+<details class="govuk-details govuk-!-margin-bottom-4">
+  <summary class="govuk-details__summary">
+    <span class="govuk-details__summary-text">When to answer yes to this question</span>
+  </summary>
+  <div class="govuk-details__text">
+    {% include "includes/dev/stranger-contact-yes-guidance.html" %}
+  </div>
+</details>
+
+<div class="govuk-form-group govuk-!-margin-bottom-0">
+  <fieldset class="govuk-fieldset">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--m govuk-visually-hidden">
+      Does {{ offenderFirstName }}'s current offence involve actual or attempted direct contact against a victim who was a stranger?
+    </legend>
+    <div class="govuk-radios govuk-radios--inline" data-module="govuk-radios">
+      <div class="govuk-radios__item">
+        <input class="govuk-radios__input" id="stranger-contact-yes" name="stranger_contact" type="radio" value="yes">
+        <label class="govuk-label govuk-radios__label" for="stranger-contact-yes">Yes</label>
+      </div>
+      <div class="govuk-radios__item">
+        <input class="govuk-radios__input" id="stranger-contact-no" name="stranger_contact" type="radio" value="no">
+        <label class="govuk-label govuk-radios__label" for="stranger-contact-no">No</label>
+      </div>
+      <div class="govuk-radios__item" hidden aria-hidden="true" style="display: none;">
+        <input class="govuk-radios__input" id="stranger-contact-unknown" name="stranger_contact" type="radio" value="unknown" disabled>
+        <label class="govuk-label govuk-radios__label" for="stranger-contact-unknown">Unknown</label>
+      </div>
+    </div>
+  </fieldset>
 </div>

--- a/app/views/includes/dev/indirect-contact-non-contact-offences-counted.html
+++ b/app/views/includes/dev/indirect-contact-non-contact-offences-counted.html
@@ -13,8 +13,15 @@
   <li>sexual penetration of a corpse</li>
 </ul>
 
+<p class="govuk-body govuk-!-margin-bottom-2">If an offence is not listed above, it should still be counted if:</p>
+<ul class="govuk-list govuk-list--bullet">
+  <li>you have explicit evidence that it has a sexual motivation</li>
+  <li>there is no actual contact or intent to have contact with a live human being</li>
+</ul>
+
 <p class="govuk-body govuk-!-margin-bottom-2">Do not count:</p>
 <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-0">
   <li>offences related to paying for or being paid for sex</li>
   <li>breach offences</li>
+  <li>convictions under the Criminal Justice and Courts Act 2015</li>
 </ul>

--- a/app/views/includes/dev/offending-history-questions.html
+++ b/app/views/includes/dev/offending-history-questions.html
@@ -4,8 +4,12 @@
   What was the date of {{ offenderFirstName }}'s first sanction?
 </h2>
 
+<div id="first-sanction-date-hint" class="govuk-hint govuk-!-margin-bottom-4">
+  We will fill in this date from previous assessment data if it is available. Change the date if it is wrong.
+</div>
+
 <div class="govuk-form-group govuk-!-margin-bottom-8" data-first-sanction-date-field>
-  <fieldset class="govuk-fieldset" role="group">
+  <fieldset class="govuk-fieldset" role="group" aria-describedby="first-sanction-date-hint">
     <legend class="govuk-fieldset__legend govuk-fieldset__legend--m govuk-visually-hidden">
       What was the date of {{ offenderFirstName }}'s first sanction?
     </legend>

--- a/app/views/includes/dev/sexual-offending-questions.html
+++ b/app/views/includes/dev/sexual-offending-questions.html
@@ -1,6 +1,6 @@
 {# Requires offenderFirstName, e.g. {% set offenderFirstName = "Alex" %} #}
 
-<h2 class="govuk-heading-m govuk-!-margin-top-0 govuk-!-margin-bottom-6">Sexual or sexually motivated offending</h2>
+<h2 class="govuk-heading-m govuk-!-margin-top-0 govuk-!-margin-bottom-6">Current and recent sexual offending</h2>
 
 {% include "includes/dev/sexual-offending-section-questions.html" %}
 

--- a/app/views/includes/dev/sexual-offending-section-questions.html
+++ b/app/views/includes/dev/sexual-offending-section-questions.html
@@ -26,41 +26,6 @@
   </fieldset>
 </div>
 
-<h3 id="predictors-stranger-contact" class="govuk-heading-s predictors-question-anchor govuk-!-margin-top-0 govuk-!-margin-bottom-2">
-  Does {{ offenderFirstName }}'s current offence involve actual or attempted direct contact against a victim who was a stranger?
-</h3>
-
-<details class="govuk-details govuk-!-margin-bottom-4">
-  <summary class="govuk-details__summary">
-    <span class="govuk-details__summary-text">When to answer yes to this question</span>
-  </summary>
-  <div class="govuk-details__text">
-    {% include "includes/dev/stranger-contact-yes-guidance.html" %}
-  </div>
-</details>
-
-<div class="govuk-form-group govuk-!-margin-bottom-8">
-  <fieldset class="govuk-fieldset">
-    <legend class="govuk-fieldset__legend govuk-fieldset__legend--m govuk-visually-hidden">
-      Does {{ offenderFirstName }}'s current offence involve actual or attempted direct contact against a victim who was a stranger?
-    </legend>
-    <div class="govuk-radios govuk-radios--inline" data-module="govuk-radios">
-      <div class="govuk-radios__item">
-        <input class="govuk-radios__input" id="stranger-contact-yes" name="stranger_contact" type="radio" value="yes">
-        <label class="govuk-label govuk-radios__label" for="stranger-contact-yes">Yes</label>
-      </div>
-      <div class="govuk-radios__item">
-        <input class="govuk-radios__input" id="stranger-contact-no" name="stranger_contact" type="radio" value="no">
-        <label class="govuk-label govuk-radios__label" for="stranger-contact-no">No</label>
-      </div>
-      <div class="govuk-radios__item" hidden aria-hidden="true" style="display: none;">
-        <input class="govuk-radios__input" id="stranger-contact-unknown" name="stranger_contact" type="radio" value="unknown" disabled>
-        <label class="govuk-label govuk-radios__label" for="stranger-contact-unknown">Unknown</label>
-      </div>
-    </div>
-  </fieldset>
-</div>
-
 <h3 id="predictors-sexual-sanction-date" class="govuk-heading-s predictors-question-anchor govuk-!-margin-top-0 govuk-!-margin-bottom-2">
   What is the date of {{ offenderFirstName }}'s most recent sanction involving a sexual or sexually motivated offence?
 </h3>

--- a/app/views/includes/direct-contact-adult-offences-counted.html
+++ b/app/views/includes/direct-contact-adult-offences-counted.html
@@ -16,7 +16,7 @@
 
 <p class="govuk-body govuk-!-margin-bottom-2">If an offence is not listed above, it should still be counted if:</p>
 <ul class="govuk-list govuk-list--bullet">
-  <li>it involves a sexual motivation</li>
+  <li>you have explicit evidence that it has a sexual motivation</li>
   <li>there is physical contact with an adult victim</li>
 </ul>
 

--- a/app/views/includes/direct-contact-child-offences-counted.html
+++ b/app/views/includes/direct-contact-child-offences-counted.html
@@ -19,7 +19,7 @@
 
 <p class="govuk-body govuk-!-margin-bottom-2">If an offence is not listed above, it should still be counted if:</p>
 <ul class="govuk-list govuk-list--bullet">
-  <li>it involves a sexual motivation</li>
+  <li>you have explicit evidence that it has a sexual motivation</li>
   <li>there is physical contact with an adult victim</li>
 </ul>
 

--- a/app/views/includes/indirect-contact-non-contact-offences-counted.html
+++ b/app/views/includes/indirect-contact-non-contact-offences-counted.html
@@ -1,4 +1,4 @@
-<p class="govuk-body govuk-!-margin-bottom-2">Count sanctions for the following sexual offences where there is no actual contact or intent to have contact with a live human being:</p>
+<p class="govuk-body govuk-!-margin-bottom-2">Count sanctions for the following offences:</p>
 <ul class="govuk-list govuk-list--bullet">
   <li>possession of extreme pornographic images</li>
   <li>sending, photographing or filming of genitals</li>
@@ -13,8 +13,15 @@
   <li>sexual penetration of a corpse</li>
 </ul>
 
+<p class="govuk-body govuk-!-margin-bottom-2">If an offence is not listed above, it should still be counted if:</p>
+<ul class="govuk-list govuk-list--bullet">
+  <li>you have explicit evidence that it has a sexual motivation</li>
+  <li>there is no actual contact or intent to have contact with a live human being</li>
+</ul>
+
 <p class="govuk-body govuk-!-margin-bottom-2">Do not count:</p>
 <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-0">
   <li>offences related to paying for or being paid for sex</li>
   <li>breach offences</li>
+  <li>convictions under the Criminal Justice and Courts Act 2015</li>
 </ul>

--- a/app/views/includes/predictors-a1b-start-content.html
+++ b/app/views/includes/predictors-a1b-start-content.html
@@ -1,0 +1,31 @@
+{# GOV.UK-style start page content for the reoffending predictors assessment #}
+<p class="govuk-body-l">
+  Use this assessment to better understand {{ offenderFirstName }}’s likelihood of reoffending.
+</p>
+
+<p class="govuk-body">
+  It brings together information about the individual and their offending history to produce reoffending predictor scores.
+</p>
+
+<h2 class="govuk-heading-m">What this assessment shows</h2>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li>Static reoffending predictor scores — based on offending history and other fixed information</li>
+  <li>Dynamic reoffending predictor scores — based on information from an interview with the individual</li>
+</ul>
+
+<h2 class="govuk-heading-m">What you need to complete this assessment</h2>
+
+<ul class="govuk-list govuk-list--bullet">
+  <li>Details of the current offence and offending history</li>
+  <li>An interview with the individual is required if you need dynamic reoffending predictor scores</li>
+</ul>
+
+<p class="govuk-body">You can still complete the static part of the assessment without an interview.</p>
+
+<a href="a2b.html" role="button" draggable="false" class="govuk-button govuk-button--start govuk-!-margin-top-6" data-module="govuk-button">
+  Start now
+  <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
+    <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"></path>
+  </svg>
+</a>

--- a/app/views/includes/predictors-community-date-question.html
+++ b/app/views/includes/predictors-community-date-question.html
@@ -1,0 +1,31 @@
+{# Predictors a4: community supervision start date (proto 2 / dev) #}
+{# Requires offenderFirstName; optional pageHeadingHintId for aria-describedby #}
+{# Question text is shown as the page heading #}
+
+<div class="govuk-form-group govuk-!-margin-top-0">
+  <fieldset class="govuk-fieldset" role="group"{% if pageHeadingHintId %} aria-describedby="{{ pageHeadingHintId }}"{% endif %}>
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--m govuk-visually-hidden">
+      What date did {{ offenderFirstName }}'s current supervision in the community begin?
+    </legend>
+    <div class="govuk-date-input" id="supervised-community-date">
+      <div class="govuk-date-input__item">
+        <div class="govuk-form-group">
+          <label class="govuk-label govuk-date-input__label" for="supervised-community-date-day">Day</label>
+          <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="supervised-community-date-day" name="supervised_community_date_day" type="text" inputmode="numeric" autocomplete="off" data-date-part="day">
+        </div>
+      </div>
+      <div class="govuk-date-input__item">
+        <div class="govuk-form-group">
+          <label class="govuk-label govuk-date-input__label" for="supervised-community-date-month">Month</label>
+          <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="supervised-community-date-month" name="supervised_community_date_month" type="text" inputmode="numeric" autocomplete="off" data-date-part="month">
+        </div>
+      </div>
+      <div class="govuk-date-input__item">
+        <div class="govuk-form-group">
+          <label class="govuk-label govuk-date-input__label" for="supervised-community-date-year">Year</label>
+          <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="supervised-community-date-year" name="supervised_community_date_year" type="text" inputmode="numeric" autocomplete="off" data-date-part="year">
+        </div>
+      </div>
+    </div>
+  </fieldset>
+</div>

--- a/app/views/layouts/assessment-proto-dev.html
+++ b/app/views/layouts/assessment-proto-dev.html
@@ -5,8 +5,8 @@
 {% extends "layouts/assessment.html" %}
 
 {% set showReturnToOasysButton = true %}
-{% set returnToOasysButtonInclude = "includes/dev/return-to-oasys-button.html" %}
-{% set journeyServiceHeaderInclude = "includes/dev/assessment-service-header-journey.html" %}
+{% set returnToOasysButtonInclude = returnToOasysButtonInclude | default("includes/dev/return-to-oasys-button.html") %}
+{% set journeyServiceHeaderInclude = journeyServiceHeaderInclude | default("includes/dev/assessment-service-header-journey.html") %}
 {% set pdsHeaderInclude = "includes/dev/pds-header.njk" %}
 {% set pdsFooterInclude = "includes/dev/pds-footer.njk" %}
 {% set primaryNavigationInclude = "includes/dev/primary-navigation.njk" %}
@@ -14,7 +14,8 @@
 {% set usePrimaryNavigation = true %}
 {% set useDevBetaPhaseBanner = true %}
 {% set hidePageHeaderSeparator = true %}
-{% set questionLegendAsHeading = true %}
+{# Keep caption + page heading in the service header (a1 layout), not as a fieldset legend #}
+{% set questionLegendAsHeading = false %}
 {% set contentColumnClass = contentColumnClass if contentColumnClass is defined else "govuk-grid-column-two-thirds-from-desktop" %}
 
 {% block pageTitle %}{% include "includes/assessment-journey-page-title.html" %}{% endblock %}

--- a/app/views/layouts/assessment-proto2.html
+++ b/app/views/layouts/assessment-proto2.html
@@ -10,7 +10,8 @@
 {% set pdsFooterInclude = "includes/02/pds-footer.njk" %}
 {% set usePdsFooter = true %}
 {% set hidePageHeaderSeparator = true %}
-{% set questionLegendAsHeading = true %}
+{# Keep caption + page heading in the service header (a1 layout), not as a fieldset legend #}
+{% set questionLegendAsHeading = false %}
 {% set contentColumnClass = contentColumnClass if contentColumnClass is defined else "govuk-grid-column-two-thirds-from-desktop" %}
 
 {% block pageTitle %}{% include "includes/assessment-journey-page-title.html" %}{% endblock %}


### PR DESCRIPTION
Key changes:
H1 Caption Nesting: Nest section captions inside for screen readers.
Single-Question Layouts: Use as fieldset on single-question pages.
Offender Header Landmark: Wrap identifiers in a landmark with more spacing.
Navigation Terminology: Rename navigation and caption labels to "Reoffending predictors".
Aria-Live Focus Fix: Fix screen reader focus lag on date-of-birth updates.
Age Calculation Cleanups: Remove age components from Dev proto a2 and a7.
No-JS Fallback Button: Add a "Calculate age" button visible only without JavaScript.
Footer Policy Links: Add Accessibility, Cookies, and Privacy policy layout links.
Dev Header Overhaul: Apply black HMPPS header and MOJ primary navigation globally.
